### PR TITLE
Fe feat/게임채널

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,6 +23,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.8.0",
+        "react-js-pagination": "^3.0.3",
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.11.1",
         "react-scripts": "5.0.1",
@@ -32,6 +33,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/react-js-pagination": "^3.0.4",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "eslint": "^8.39.0",
@@ -4217,6 +4219,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-js-pagination": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/react-js-pagination/-/react-js-pagination-3.0.4.tgz",
+      "integrity": "sha512-yka+27eZ6Mg9cmwT2sADgLn3ij9hVfpPu5dk+Y/0k1xS52WZOz0LJnn4y4VKGmR4mf/tG5Ga7Dody/xmfiB0Fg==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -5576,6 +5587,17 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
+      "dependencies": {
+        "inherits": "~2.0.0"
+      },
+      "engines": {
+        "node": "0.4 || >=0.5.8"
       }
     },
     "node_modules/bluebird": {
@@ -8837,6 +8859,31 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/function-bind": {
@@ -13364,6 +13411,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/paginator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/paginator/-/paginator-1.0.0.tgz",
+      "integrity": "sha512-j2Y5AtF/NrXOEU9VVOQBGHnj81NveRQ/cDzySywqsWrAj+cxivMpMCkYJOds3ulQiDU4rQBWc0WoyyXMXOmuMA=="
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -15949,6 +16001,32 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-js-pagination": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/react-js-pagination/-/react-js-pagination-3.0.3.tgz",
+      "integrity": "sha512-podyA6Rd0uxc8uQakXWXxnonoOPI6NnFOROXfc6qPKNYm44s+Bgpn0JkyflcfbHf/GFKahnL8JN8rxBHZiBskg==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "fstream": "1.0.12",
+        "paginator": "^1.0.0",
+        "prop-types": "15.x.x - 16.x.x",
+        "react": "15.x.x - 16.x.x",
+        "tar": "2.2.2"
+      }
+    },
+    "node_modules/react-js-pagination/node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-redux": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
@@ -17678,6 +17756,17 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "deprecated": "This version of tar is no longer supported, and will not receive security updates. Please upgrade asap.",
+      "dependencies": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
       }
     },
     "node_modules/temp-dir": {
@@ -22092,6 +22181,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-js-pagination": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/react-js-pagination/-/react-js-pagination-3.0.4.tgz",
+      "integrity": "sha512-yka+27eZ6Mg9cmwT2sADgLn3ij9hVfpPu5dk+Y/0k1xS52WZOz0LJnn4y4VKGmR4mf/tG5Ga7Dody/xmfiB0Fg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -23132,6 +23230,14 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
+      "requires": {
+        "inherits": "~2.0.0"
+      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -25490,6 +25596,27 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "optional": true
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -28781,6 +28908,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
+    "paginator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/paginator/-/paginator-1.0.0.tgz",
+      "integrity": "sha512-j2Y5AtF/NrXOEU9VVOQBGHnj81NveRQ/cDzySywqsWrAj+cxivMpMCkYJOds3ulQiDU4rQBWc0WoyyXMXOmuMA=="
+    },
     "param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -30445,6 +30577,31 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-js-pagination": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/react-js-pagination/-/react-js-pagination-3.0.3.tgz",
+      "integrity": "sha512-podyA6Rd0uxc8uQakXWXxnonoOPI6NnFOROXfc6qPKNYm44s+Bgpn0JkyflcfbHf/GFKahnL8JN8rxBHZiBskg==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "fstream": "1.0.12",
+        "paginator": "^1.0.0",
+        "prop-types": "15.x.x - 16.x.x",
+        "react": "15.x.x - 16.x.x",
+        "tar": "2.2.2"
+      },
+      "dependencies": {
+        "react": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        }
+      }
+    },
     "react-redux": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
@@ -31693,6 +31850,16 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+    },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
     },
     "temp-dir": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",
+    "react-js-pagination": "^3.0.3",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.11.1",
     "react-scripts": "5.0.1",
@@ -48,6 +49,7 @@
     ]
   },
   "devDependencies": {
+    "@types/react-js-pagination": "^3.0.4",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "eslint": "^8.39.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,7 +15,7 @@ const App = () => {
         <Route path='/' element={<Template />}>
           <Route path='/' element={<Home />} />
           <Route path='/category/:id' element={<CategoryGames />} />
-          <Route path='/games/:id' element={<GameChannel />} />
+          <Route path='/games/:gameId' element={<GameChannel />} />
           <Route path='/signup' element={<SignUp />} />
         </Route>
       </Routes>

--- a/client/src/components/common/FilterTap.tsx
+++ b/client/src/components/common/FilterTap.tsx
@@ -1,14 +1,18 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
-const FilterTap = ({ filterList }: { filterList: string[]})  => {
+type Props = {
+  filterList: string[];
+  onClickFilter: (item: string) => void;
+};
 
-  // todo: 클릭한 상태값 담아서 내보내기
+const FilterTap = ({ filterList, onClickFilter }: Props)  => {
 
   const [activeIndex, setActiveIndex] = useState(0);
 
-  const handleItemClick = (index: number) => {
+  const handleItemClick = (item: string, index: number) => {
     setActiveIndex(index);
+    onClickFilter(item);
   };
 
   return (
@@ -18,7 +22,7 @@ const FilterTap = ({ filterList }: { filterList: string[]})  => {
           <FiterItem
             key={index}
             className={activeIndex === index ? 'active' : ''}
-            onClick={() => handleItemClick(index)}
+            onClick={() => handleItemClick(item, index)}
           >
             {item}
           </FiterItem>

--- a/client/src/data/dummyPostList.ts
+++ b/client/src/data/dummyPostList.ts
@@ -119,5 +119,89 @@ export const dummyPostList: PostListResponse = {
       'likeCount': 25,
       'commentCount': 5
     },
+    {
+      'postId': 8,
+      'title': '8 번째 게시글',
+      'tag': '모집',
+      'createdAt': '2022-05-09T09:25:00Z',
+      'updatedAt': '2022-05-09T09:25:00Z',
+      'view': 100,
+      'userName': 'user1',
+      'memberStatus': '', 
+      'likeCount': 20,
+      'commentCount': 10
+    },
+    {
+      'postId': 9,
+      'title': '9 번째 게시글',
+      'tag': '공략',
+      'createdAt': '2022-05-10T12:30:00Z',
+      'updatedAt': '2022-05-10T12:30:00Z',
+      'view': 200,
+      'userName': 'user2',
+      'memberStatus': '', 
+      'likeCount': 10,
+      'commentCount': 5
+    },
+    {
+      'postId': 10,
+      'title': '10 번째 게시글',
+      'tag': '질문',
+      'createdAt': '2022-05-11T18:45:00Z',
+      'updatedAt': '2022-05-11T18:45:00Z',
+      'view': 50,
+      'userName': 'user3',
+      'memberStatus': '', 
+      'likeCount': 5,
+      'commentCount': 2
+    },
+    {
+      'postId': 11,
+      'title': '11 번째 게시글',
+      'tag': '모집',
+      'createdAt': '2022-05-11T19:45:00Z',
+      'updatedAt': '2022-05-11T19:45:00Z',
+      'view': 51,
+      'userName': 'user3',
+      'memberStatus': '', 
+      'likeCount': 23,
+      'commentCount': 3
+    },
+    {
+      'postId': 12,
+      'title': '12 번째 게시글',
+      'tag': '모집',
+      'createdAt': '2023-05-11T03:10:00Z',
+      'updatedAt': '2023-05-11T03:10:00Z',
+      'view': 51,
+      'userName': 'user3',
+      'memberStatus': '', 
+      'likeCount': 24,
+      'commentCount': 4
+    },
+    {
+      'postId': 13,
+      'title': '13 번째 게시글',
+      'tag': '모집',
+      'createdAt': '2023-05-13T10:14:16.244Z',
+      'updatedAt': '2023-05-13T10:14:16.244Z',
+      'view': 51,
+      'userName': 'user3',
+      'memberStatus': '', 
+      'likeCount': 24,
+      'commentCount': 4
+    },
+    {
+      'postId': 14,
+      'title': '14 번째 게시글',
+      'tag': '모집',
+      'createdAt': '2023-05-13T10:14:19.700Z',
+      'updatedAt': '2023-05-13T10:14:19.700Z',
+      'view': 49,
+      'userName': 'user3',
+      'memberStatus': '', 
+      'likeCount': 25,
+      'commentCount': 5
+    },
   ]
 };

--- a/client/src/data/dummyPostList.ts
+++ b/client/src/data/dummyPostList.ts
@@ -1,0 +1,123 @@
+/*
+{
+post:[
+    postId,
+    title, 
+    tag, 
+    createdAt, 
+    updatedAt, 
+    view, 
+    userName, 
+    memberStatus, 
+    likeCount, 
+    commentCount, 
+    ...
+  ]
+}
+ */
+
+export type Post = {
+  postId: number;
+  title: string;
+  tag: string;
+  createdAt: string;
+  updatedAt: string;
+  view: number;
+  userName: string;
+  memberStatus: string;
+  likeCount: number;
+  commentCount: number;
+};
+
+type PostListResponse = {
+  post: Post[];
+};
+
+export const dummyPostList: PostListResponse = {
+  'post': [
+    {
+      'postId': 1,
+      'title': '첫 번째 게시글',
+      'tag': '모집',
+      'createdAt': '2022-05-09T09:25:00Z',
+      'updatedAt': '2022-05-09T09:25:00Z',
+      'view': 100,
+      'userName': 'user1',
+      'memberStatus': '', 
+      'likeCount': 20,
+      'commentCount': 10
+    },
+    {
+      'postId': 2,
+      'title': '두 번째 게시글',
+      'tag': '공략',
+      'createdAt': '2022-05-10T12:30:00Z',
+      'updatedAt': '2022-05-10T12:30:00Z',
+      'view': 200,
+      'userName': 'user2',
+      'memberStatus': '', 
+      'likeCount': 10,
+      'commentCount': 5
+    },
+    {
+      'postId': 3,
+      'title': '세 번째 게시글',
+      'tag': '질문',
+      'createdAt': '2022-05-11T18:45:00Z',
+      'updatedAt': '2022-05-11T18:45:00Z',
+      'view': 50,
+      'userName': 'user3',
+      'memberStatus': '', 
+      'likeCount': 5,
+      'commentCount': 2
+    },
+    {
+      'postId': 4,
+      'title': '네 번째 게시글',
+      'tag': '모집',
+      'createdAt': '2022-05-11T19:45:00Z',
+      'updatedAt': '2022-05-11T19:45:00Z',
+      'view': 51,
+      'userName': 'user3',
+      'memberStatus': '', 
+      'likeCount': 23,
+      'commentCount': 3
+    },
+    {
+      'postId': 5,
+      'title': '다섯 번째 게시글',
+      'tag': '모집',
+      'createdAt': '2023-05-11T03:10:00Z',
+      'updatedAt': '2023-05-11T03:10:00Z',
+      'view': 51,
+      'userName': 'user3',
+      'memberStatus': '', 
+      'likeCount': 24,
+      'commentCount': 4
+    },
+    {
+      'postId': 6,
+      'title': '여섯 번째 게시글',
+      'tag': '모집',
+      'createdAt': '2023-05-13T10:14:16.244Z',
+      'updatedAt': '2023-05-13T10:14:16.244Z',
+      'view': 51,
+      'userName': 'user3',
+      'memberStatus': '', 
+      'likeCount': 24,
+      'commentCount': 4
+    },
+    {
+      'postId': 7,
+      'title': '일곱 번째 게시글',
+      'tag': '모집',
+      'createdAt': '2023-05-13T10:14:19.700Z',
+      'updatedAt': '2023-05-13T10:14:19.700Z',
+      'view': 49,
+      'userName': 'user3',
+      'memberStatus': '', 
+      'likeCount': 25,
+      'commentCount': 5
+    },
+  ]
+};

--- a/client/src/data/dummyPostList.ts
+++ b/client/src/data/dummyPostList.ts
@@ -205,3 +205,85 @@ export const dummyPostList: PostListResponse = {
     },
   ]
 };
+
+export const dummyBookmarkList: PostListResponse = {
+  'post': [
+    {
+      'postId': 1,
+      'title': '첫 번째 게시글',
+      'tag': '모집',
+      'createdAt': '2022-05-09T09:25:00Z',
+      'updatedAt': '2022-05-09T09:25:00Z',
+      'view': 100,
+      'userName': 'user1',
+      'memberStatus': '', 
+      'likeCount': 20,
+      'commentCount': 10
+    },
+    {
+      'postId': 2,
+      'title': '두 번째 게시글',
+      'tag': '공략',
+      'createdAt': '2022-05-10T12:30:00Z',
+      'updatedAt': '2022-05-10T12:30:00Z',
+      'view': 200,
+      'userName': 'user2',
+      'memberStatus': '', 
+      'likeCount': 10,
+      'commentCount': 5
+    },
+    {
+      'postId': 3,
+      'title': '세 번째 게시글',
+      'tag': '질문',
+      'createdAt': '2022-05-11T18:45:00Z',
+      'updatedAt': '2022-05-11T18:45:00Z',
+      'view': 50,
+      'userName': 'user3',
+      'memberStatus': '', 
+      'likeCount': 5,
+      'commentCount': 2
+    },
+  ]
+};
+
+export const dummyMyList: PostListResponse = {
+  'post': [
+    {
+      'postId': 1,
+      'title': '내가 쓴 1번째 게시글',
+      'tag': '모집',
+      'createdAt': '2022-05-09T09:25:00Z',
+      'updatedAt': '2022-05-09T09:25:00Z',
+      'view': 100,
+      'userName': 'user11',
+      'memberStatus': '', 
+      'likeCount': 20,
+      'commentCount': 10
+    },
+    {
+      'postId': 2,
+      'title': '내가 쓴 2번째 게시글',
+      'tag': '공략',
+      'createdAt': '2022-05-10T12:30:00Z',
+      'updatedAt': '2022-05-10T12:30:00Z',
+      'view': 200,
+      'userName': 'user11',
+      'memberStatus': '', 
+      'likeCount': 10,
+      'commentCount': 5
+    },
+    {
+      'postId': 3,
+      'title': '내가 쓴 3번째 게시글',
+      'tag': '질문',
+      'createdAt': '2022-05-11T18:45:00Z',
+      'updatedAt': '2022-05-11T18:45:00Z',
+      'view': 50,
+      'userName': 'user11',
+      'memberStatus': '', 
+      'likeCount': 5,
+      'commentCount': 2
+    },
+  ]
+};

--- a/client/src/data/filterTapList.ts
+++ b/client/src/data/filterTapList.ts
@@ -1,0 +1,14 @@
+export const gameChannelFilterTab: string[] = [
+  '최신순', 
+  '인기순', 
+  '조회순',
+  '북마크 글', 
+  '내가 쓴 글'
+];
+
+export const categoryFilterTab: string[] = [
+  '전체 게임',
+  '인기 게임', 
+  '신규 게임', 
+  '팔로우 게임'
+];

--- a/client/src/data/postOptionTags.ts
+++ b/client/src/data/postOptionTags.ts
@@ -1,0 +1,23 @@
+// 모집, 버그, 공략, 수다, 정보, 팬아트, 질문, 문의(건의), 자랑하기, 후기, 기타
+
+type Option = {
+  value: string;
+  label: string;
+};
+
+const postOptionTags: Option[] = [
+  { value: '전체', label: '전체' },
+  { value: '모집', label: '모집' },
+  { value: '버그', label: '버그' },
+  { value: '공략', label: '공략' },
+  { value: '수다', label: '수다' },
+  { value: '정보', label: '정보' },
+  { value: '팬아트', label: '팬아트' },
+  { value: '질문', label: '질문' },
+  { value: '문의', label: '문의' },
+  { value: '자랑', label: '자랑' },
+  { value: '후기', label: '후기' },
+  { value: '기타', label: '기타' },
+];
+
+export default postOptionTags;

--- a/client/src/layouts/GameChannel/GameTitle.tsx
+++ b/client/src/layouts/GameChannel/GameTitle.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { dummyGameData, Game } from '../../data/dummyCategories';
+import { dummyGameData } from '../../data/dummyCategories';
 import CategoryTag from '../../components/common/CategoryTag';
 import CreateChannelButton from '../../components/ui/CreateChannelButton';
 
-const GameTitle = ()  => {
+const GameTitle = ({ gameId }: { gameId: string | undefined})  => {
 
-  const { id } = useParams();
-  const game: Game | undefined = dummyGameData.find(item => item.gameId.toString() === id);
+  const game = dummyGameData.find(item => item.gameId.toString() === gameId);
   const followNumber = 10; // 데이터패칭 해야됨 + 팔로우 기능추가 (버튼클릭시 텍스트변경)
 
   if (!game) {

--- a/client/src/layouts/GameChannel/GameTitle.tsx
+++ b/client/src/layouts/GameChannel/GameTitle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store/store';
 import styled from 'styled-components';
@@ -7,14 +7,19 @@ import { dummyGameData } from '../../data/dummyCategories';
 import CategoryTag from '../../components/common/CategoryTag';
 import CreateChannelButton from '../../components/ui/CreateChannelButton';
 
-const GameTitle = ({ gameId }: { gameId: string | undefined})  => {
+// todo: 게임 팔로우 기능 추가, 게임아이디에 맞게 게임 데이터 패칭, 경로 쿼리 재설정
+
+const GameTitle = ()  => {
   
+  const { gameId } = useParams();
+  const memberId = useSelector((state: RootState) => state.user.memberId);
+
   const navigate = useNavigate();
   const game = dummyGameData.find(item => item.gameId.toString() === gameId);
   const followNumber = 10; // 데이터패칭 해야됨 + 팔로우 기능추가 (버튼클릭시 텍스트변경)
-  const memberId = useSelector((state: RootState) => state.user.memberId);
 
   if (!game) {
+    // 게임이 없을때 404페이지로 변경
     return <div>게임을 찾을 수 없습니다.</div>
   }
 

--- a/client/src/layouts/GameChannel/GameTitle.tsx
+++ b/client/src/layouts/GameChannel/GameTitle.tsx
@@ -1,19 +1,32 @@
 import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../store/store';
 import styled from 'styled-components';
 import { dummyGameData } from '../../data/dummyCategories';
 import CategoryTag from '../../components/common/CategoryTag';
 import CreateChannelButton from '../../components/ui/CreateChannelButton';
 
 const GameTitle = ({ gameId }: { gameId: string | undefined})  => {
-
+  
+  const navigate = useNavigate();
   const game = dummyGameData.find(item => item.gameId.toString() === gameId);
   const followNumber = 10; // 데이터패칭 해야됨 + 팔로우 기능추가 (버튼클릭시 텍스트변경)
+  const memberId = useSelector((state: RootState) => state.user.memberId);
 
   if (!game) {
     return <div>게임을 찾을 수 없습니다.</div>
   }
 
   const currentGameData = game.categories;
+
+  const handleFollow = () => {
+    if (memberId === -1) {
+      navigate('/login');
+    } else {
+      console.log('게임 팔로우 기능 추가');
+    }
+  }
 
   return (
     <StyledTitleWrapper>
@@ -36,8 +49,15 @@ const GameTitle = ({ gameId }: { gameId: string | undefined})  => {
       }
       </StyledTagContain>
       <StyledFollowContain>
-        <p>게임 팔로워: {followNumber}</p>
-        <CreateChannelButton text='게임 팔로우' onClick={() => {console.log('팔로우 기능추가')}}/>
+      <Link to={`/games/${gameId}/follower`} >
+        <StyledFollowNumber>
+          게임 팔로워: {followNumber}
+        </StyledFollowNumber>
+      </Link>
+        <CreateChannelButton 
+          text='게임 팔로우' 
+          onClick={handleFollow}
+        />
       </StyledFollowContain>
     </StyledTitleWrapper>
   );
@@ -102,3 +122,10 @@ const StyledFollowContain = styled.div`
     width: 80%;
   }
 `;
+
+const StyledFollowNumber = styled.p`
+  cursor: pointer;
+  &:hover {
+    color: var(--cyan-dark-700);
+  }
+`

--- a/client/src/layouts/GameChannel/PostItem.tsx
+++ b/client/src/layouts/GameChannel/PostItem.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import CategoryTag from '../../components/common/CategoryTag';
-import { StarTwoTone } from '@ant-design/icons';
 import { Post } from '../../data/dummyPostList';
+import { StarTwoTone } from '@ant-design/icons';
 
 const PostItem = ({
   postId,
@@ -18,16 +18,14 @@ const PostItem = ({
   commentCount
 }: Post)  => {
 
-  const { id } = useParams();
+  const { gameId } = useParams();
   const [ isMarked, setMarked ] = useState(false);
 
   const handleMark = () => {
     setMarked((prev) => !prev)
   }
 
-  // 필터링 데이터패칭 해서 받아와야됨, 페이지네이션,글자수 제한 ...
-  // 날짜 분, 시, 일, 년전
-  // 북마크,내가쓴글,팔로우 로그인상태만 허용
+  // todo: 게시글 팔로우 기능 추가, 날짜 분, 시, 일, 년전, 제목 글자수 제한 ... 으로 바꾸기, 경로 쿼리 재설정
 
   const dateStr = createdAt;
   const date = new Date(dateStr);
@@ -43,7 +41,7 @@ const PostItem = ({
     <StyledWrapper>
       <StyledContent>
         <StyledFlexRow>
-        <Link to={`/games/${id}/posts/${postId}`}>
+        <Link to={`/games/${gameId}/posts/${postId}`}>
           <StyledTitle>
             {title}
           </StyledTitle>

--- a/client/src/layouts/GameChannel/PostItem.tsx
+++ b/client/src/layouts/GameChannel/PostItem.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import CategoryTag from '../../components/common/CategoryTag';
 import { StarTwoTone } from '@ant-design/icons';
@@ -17,6 +18,7 @@ const PostItem = ({
   commentCount
 }: Post)  => {
 
+  const { id } = useParams();
   const [ isMarked, setMarked ] = useState(false);
 
   const handleMark = () => {
@@ -41,9 +43,11 @@ const PostItem = ({
     <StyledWrapper>
       <StyledContent>
         <StyledFlexRow>
+        <Link to={`/games/${id}/posts/${postId}`}>
           <StyledTitle>
             {title}
           </StyledTitle>
+        </Link>
           <CategoryTag index={0} categoryName={tag} />
         </StyledFlexRow>
         <StyledFlexRow>

--- a/client/src/layouts/GameChannel/PostItem.tsx
+++ b/client/src/layouts/GameChannel/PostItem.tsx
@@ -2,8 +2,20 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import CategoryTag from '../../components/common/CategoryTag';
 import { StarTwoTone } from '@ant-design/icons';
+import { Post } from '../../data/dummyPostList';
 
-const PostItem = ()  => {
+const PostItem = ({
+  postId,
+  title,
+  tag,
+  createdAt,
+  updatedAt,
+  view,
+  userName,
+  memberStatus,
+  likeCount,
+  commentCount
+}: Post)  => {
 
   const [ isMarked, setMarked ] = useState(false);
 
@@ -11,29 +23,46 @@ const PostItem = ()  => {
     setMarked((prev) => !prev)
   }
 
-  // 필터링 데이터패칭 해서 받아와야됨, 글자수 제한 ... 
+  // 필터링 데이터패칭 해서 받아와야됨, 페이지네이션,글자수 제한 ...
+  // 날짜 분, 시, 일, 년전
+  // 북마크,내가쓴글,팔로우 로그인상태만 허용
+
+  const dateStr = createdAt;
+  const date = new Date(dateStr);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hour = date.getHours();
+  const minute = date.getMinutes();
+
+  const formattedDate = `${year}년 ${month}월 ${day}일 ${hour}시 ${minute}분`;
 
   return (
     <StyledWrapper>
       <StyledContent>
         <StyledFlexRow>
           <StyledTitle>
-            제목 엄청나게 긴 제목제목 엄청나게 긴 제목 ...
+            {title}
           </StyledTitle>
-          <CategoryTag index={0} categoryName='모집'/>
+          <CategoryTag index={0} categoryName={tag} />
         </StyledFlexRow>
         <StyledFlexRow>
           <StyledInfo>
-            <p>작성자: </p>
-            <p>작성일: </p>
-            <p>추천수: </p>
-            <p>조회수: </p>      
+            <StyledSpan>작성자:</StyledSpan>
+            {userName}
+            <StyledSpan>작성일:</StyledSpan>
+            {formattedDate}
+            <StyledSpan>추천 수:</StyledSpan>
+            {likeCount}
+            <StyledSpan>조회 수:</StyledSpan>
+            {view}
           </StyledInfo>
         </StyledFlexRow>
       </StyledContent>
       <StyledFlexRow>
       <StyledInfo>
-        <p>댓글: 0</p>
+        <StyledSpan>댓글:</StyledSpan>
+        {commentCount}
         <StarTwoTone
           onClick={handleMark}
           twoToneColor={ isMarked ? '#13A8A8'  : '#b4b4b4' }
@@ -53,7 +82,7 @@ const StyledWrapper = styled.div`
   align-items: center;
   padding: 25px 10px;
   border-bottom: 1px solid green;
-  cursor: pointer;
+
   &:hover {
     box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
   }
@@ -78,15 +107,24 @@ const StyledTitle = styled.h3`
   margin-right: 20px;
   word-break: keep-all;
   overflow-wrap: break-word;
+  cursor: pointer;
+  &:hover {
+    color: var(--cyan-light-800);
+  }
 `;
 
-const StyledInfo = styled.p`
+const StyledInfo = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-content: center;
-  gap: 10px;
+  gap: 5px;
   margin-top: 10px;
-  font-size: 14px;
+  font-size: 12px;
   color: var(--default-text-color);
-`
+`;
+
+const StyledSpan = styled.span`
+  font-weight: 600;
+  color: var(--sub-text-color);
+`;

--- a/client/src/layouts/GameChannel/PostList.tsx
+++ b/client/src/layouts/GameChannel/PostList.tsx
@@ -1,18 +1,23 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import axios from 'axios';
 import Pagination from 'react-js-pagination';
 import PostItem from './PostItem';
-import { dummyPostList } from '../../data/dummyPostList';
+import { dummyPostList, dummyBookmarkList, dummyMyList } from '../../data/dummyPostList';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../store/store';
 
 interface Props {
   gameId?: string;
   isSelectTab: string;
   isSelectTag: string;
-}
+};
 
 const PostList: React.FC<Props> = ({ gameId, isSelectTag ,isSelectTab }) => {
   const [filteredPosts, setFilteredPosts] = useState(dummyPostList.post);
   const [page, setPage] = useState(1);
+  const [userMessage, setUserMessage ] = useState('작성된 게시글이 없습니다.');
+  const memberId = useSelector((state: RootState) => state.user.memberId);
 
   const handlePageChange = (page: number) => {
     setPage(page);
@@ -20,7 +25,10 @@ const PostList: React.FC<Props> = ({ gameId, isSelectTag ,isSelectTab }) => {
 
   useEffect(() => {
     setPage(1);
+    setUserMessage('작성된 게시글이 없습니다.');
     const postData = dummyPostList.post;
+    const bookmarkData = dummyBookmarkList.post;
+    const myPostData = dummyMyList.post;
   
     switch (isSelectTab) {
       case '최신순':
@@ -32,6 +40,42 @@ const PostList: React.FC<Props> = ({ gameId, isSelectTag ,isSelectTab }) => {
       case '조회순':
         setFilteredPosts([...postData].sort((a, b) => b.view - a.view));
         break;
+      case '북마크 글':
+        if (memberId === -1) {
+          setFilteredPosts([]);
+          setUserMessage('로그인이 필요한 기능입니다.');
+        } else {
+          // 로그인 후 북마크한 글들을 가져오는 코드 작성
+          /* api 연결시 사용
+          axios.get(`${process.env.REACT_APP_API_URL}/api/members/${memberId}/bookmark`)
+            .then((response) => {
+              setFilteredPosts(response.data);
+            })
+            .catch((error) => {
+              console.error(error);
+            });
+          */
+          setFilteredPosts([...bookmarkData].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()));
+        }
+        break;
+      case '내가 쓴 글':
+        if (memberId === -1) {
+          setFilteredPosts([]);
+          setUserMessage('로그인이 필요한 기능입니다.');
+        } else {
+          // 로그인 후 내가 쓴 글들을 가져오는 코드 작성
+          /* api 연결시 사용
+          axios.get(`${process.env.REACT_APP_API_URL}/api/members/${memberId}/mypost`)
+            .then((response) => {
+              setFilteredPosts(response.data);
+            })
+            .catch((error) => {
+              console.error(error);
+            });
+          */
+          setFilteredPosts([...myPostData].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()));
+        }
+        break;
       default:
         setFilteredPosts(postData);
         break;
@@ -40,7 +84,7 @@ const PostList: React.FC<Props> = ({ gameId, isSelectTag ,isSelectTab }) => {
     if (isSelectTag !== '전체') {
       setFilteredPosts((prev) => prev.filter((post) => post.tag === isSelectTag));
     }
-  }, [isSelectTab, isSelectTag]);
+  }, [isSelectTab, isSelectTag, memberId]);
 
   const ITEMS_PER_PAGE = 10;
   const lastIndex = page * ITEMS_PER_PAGE;
@@ -67,7 +111,7 @@ const PostList: React.FC<Props> = ({ gameId, isSelectTag ,isSelectTab }) => {
           />
         )) :
         <StyledEmptyItem>
-          작성된 게시글이 없습니다.
+          {userMessage}
         </StyledEmptyItem>
       }
       <StyledPagination>
@@ -100,7 +144,7 @@ const StyledEmptyItem = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 50px;
+  padding: 50px 0px;
   font-size: 18px;
   font-weight: 700;
   color: var(--default-text-color);

--- a/client/src/layouts/GameChannel/PostList.tsx
+++ b/client/src/layouts/GameChannel/PostList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import Pagination from 'react-js-pagination';
 import PostItem from './PostItem';
 import { dummyPostList } from '../../data/dummyPostList';
 
@@ -11,8 +12,14 @@ interface Props {
 
 const PostList: React.FC<Props> = ({ gameId, isSelectTag ,isSelectTab }) => {
   const [filteredPosts, setFilteredPosts] = useState(dummyPostList.post);
+  const [page, setPage] = useState(1);
+
+  const handlePageChange = (page: number) => {
+    setPage(page);
+  };
 
   useEffect(() => {
+    setPage(1);
     const postData = dummyPostList.post;
   
     switch (isSelectTab) {
@@ -35,15 +42,18 @@ const PostList: React.FC<Props> = ({ gameId, isSelectTag ,isSelectTab }) => {
     }
   }, [isSelectTab, isSelectTag]);
 
-  console.log(filteredPosts);
+  const ITEMS_PER_PAGE = 10;
+  const lastIndex = page * ITEMS_PER_PAGE;
+  const firstIndex = lastIndex - ITEMS_PER_PAGE;
+  const currentPagePosts = filteredPosts.slice(firstIndex, lastIndex);
 
   return (
     <PostListWrapper>
       {
-        filteredPosts.length > 0 ? 
-        filteredPosts.map((post) => (
+        currentPagePosts.length > 0 ? 
+        currentPagePosts.map((post, index) => (
           <PostItem
-            key={post.postId}
+            key={index}
             postId={post.postId}
             title={post.title}
             tag={post.tag}
@@ -55,11 +65,22 @@ const PostList: React.FC<Props> = ({ gameId, isSelectTag ,isSelectTab }) => {
             likeCount={post.likeCount}
             commentCount={post.commentCount}
           />
-        )) : 
+        )) :
         <StyledEmptyItem>
           작성된 게시글이 없습니다.
         </StyledEmptyItem>
       }
+      <StyledPagination>
+      <Pagination
+        activePage={page}
+        itemsCountPerPage={10}
+        totalItemsCount={filteredPosts.length}
+        pageRangeDisplayed={5}
+        prevPageText={'‹'}
+        nextPageText={'›'}
+        onChange={handlePageChange}
+    />
+    </StyledPagination>
     </PostListWrapper>
   );
 };
@@ -69,8 +90,6 @@ export default PostList;
 const PostListWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  overflow-y: scroll;
-  max-height: 380px;
   @media screen and (max-width: 650px) {
     padding: 0px 5px;
     max-height: 100%;
@@ -85,4 +104,62 @@ const StyledEmptyItem = styled.div`
   font-size: 18px;
   font-weight: 700;
   color: var(--default-text-color);
+`;
+
+const StyledPagination = styled.div`
+  padding: 20px;
+  .pagination {
+    display: flex;
+    justify-content: center;
+    margin-top: 15px;
+  }
+  
+  ul {
+    list-style: none;
+    padding: 0;
+  }
+  
+  ul.pagination li {
+    display: inline-block;
+    width: 30px;
+    height: 30px;
+    border: 1px solid var(--loding-bg);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 1rem;
+  }
+
+  ul.pagination li:first-child{
+    border-radius: 5px 0 0 5px;
+  }
+
+  ul.pagination li:last-child{
+    border-radius: 0 5px 5px 0;
+  }
+  
+  ul.pagination li a {
+    text-decoration: none;
+    color: var(--cyan-light-600);
+    font-size: 1rem;
+  }
+  
+  ul.pagination li.active a {
+    color: white;
+  }
+
+  ul.pagination li.active {
+    background-color: var(--cyan-light-800);
+  }
+  
+  ul.pagination li a:hover,
+  ul.pagination li a.active {
+    color: var(--cyan-light-300);
+  }
+  
+  .page-selection {
+    width: 48px;
+    height: 30px;
+    color: var(--cyan-light-800);
+  }
 `;

--- a/client/src/layouts/GameChannel/PostList.tsx
+++ b/client/src/layouts/GameChannel/PostList.tsx
@@ -1,23 +1,68 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import PostItem from './PostItem';
+import { dummyPostList } from '../../data/dummyPostList';
 
-const PostList = ()  => {
+interface Props {
+  gameId?: string;
+  isSelectTab: string;
+  isSelectTag: string;
+}
+
+const PostList: React.FC<Props> = ({ gameId, isSelectTag ,isSelectTab }) => {
+  const [filteredPosts, setFilteredPosts] = useState(dummyPostList.post);
+
+  useEffect(() => {
+    const postData = dummyPostList.post;
+  
+    switch (isSelectTab) {
+      case '최신순':
+        setFilteredPosts([...postData].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()));
+        break;
+      case '인기순':
+        setFilteredPosts([...postData].sort((a, b) => b.likeCount - a.likeCount));
+        break;
+      case '조회순':
+        setFilteredPosts([...postData].sort((a, b) => b.view - a.view));
+        break;
+      default:
+        setFilteredPosts(postData);
+        break;
+    }
+
+    if (isSelectTag !== '전체') {
+      setFilteredPosts((prev) => prev.filter((post) => post.tag === isSelectTag));
+    }
+  }, [isSelectTab, isSelectTag]);
+
+  console.log(filteredPosts);
+
   return (
     <PostListWrapper>
-      <PostItem />
-      <PostItem />
-      <PostItem />
-      <PostItem />
-      <PostItem />
-      <PostItem />
-      <PostItem />
-      <PostItem />
-      <PostItem />
-      <PostItem />
+      {
+        filteredPosts.length > 0 ? 
+        filteredPosts.map((post) => (
+          <PostItem
+            key={post.postId}
+            postId={post.postId}
+            title={post.title}
+            tag={post.tag}
+            createdAt={post.createdAt}
+            updatedAt={post.updatedAt}
+            view={post.view}
+            userName={post.userName}
+            memberStatus={post.memberStatus}
+            likeCount={post.likeCount}
+            commentCount={post.commentCount}
+          />
+        )) : 
+        <StyledEmptyItem>
+          작성된 게시글이 없습니다.
+        </StyledEmptyItem>
+      }
     </PostListWrapper>
-  )
-}
+  );
+};
 
 export default PostList;
 
@@ -30,4 +75,14 @@ const PostListWrapper = styled.div`
     padding: 0px 5px;
     max-height: 100%;
   }
+`;
+
+const StyledEmptyItem = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 50px;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--default-text-color);
 `;

--- a/client/src/layouts/GameChannel/PostList.tsx
+++ b/client/src/layouts/GameChannel/PostList.tsx
@@ -1,24 +1,29 @@
 import React, { useEffect, useState } from 'react';
-import styled from 'styled-components';
+import { useParams } from 'react-router-dom';
 import axios from 'axios';
-import Pagination from 'react-js-pagination';
-import PostItem from './PostItem';
-import { dummyPostList, dummyBookmarkList, dummyMyList } from '../../data/dummyPostList';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store/store';
+import Pagination from 'react-js-pagination';
+import styled from 'styled-components';
+import PostItem from './PostItem';
+import { dummyPostList, dummyBookmarkList, dummyMyList } from '../../data/dummyPostList';
 
 interface Props {
-  gameId?: string;
   isSelectTab: string;
   isSelectTag: string;
 };
 
-const PostList: React.FC<Props> = ({ gameId, isSelectTag ,isSelectTab }) => {
+// todo: 게임아이디에 맞게 게시글 데이터 패칭
+
+const PostList: React.FC<Props> = ({ isSelectTag ,isSelectTab }) => {
+  
+  const { gameId } = useParams();
+  const memberId = useSelector((state: RootState) => state.user.memberId);
+
   const [filteredPosts, setFilteredPosts] = useState(dummyPostList.post);
   const [page, setPage] = useState(1);
   const [userMessage, setUserMessage ] = useState('작성된 게시글이 없습니다.');
-  const memberId = useSelector((state: RootState) => state.user.memberId);
-
+ 
   const handlePageChange = (page: number) => {
     setPage(page);
   };

--- a/client/src/pages/CategoryGames.tsx
+++ b/client/src/pages/CategoryGames.tsx
@@ -1,20 +1,26 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import GameList from '../layouts/CategoryGames/GameList';
 import FilterTap from '../components/common/FilterTap';
 import RecommendGames from '../layouts/CategoryGames/RecommendGames';
 import TitleCategory from '../layouts/CategoryGames/TitleCategory';
+import { categoryFilterTab } from '../data/filterTapList';
 
 const CategoryGames = () => {
 
-  const filterList = ['전체 게임', '인기 게임', '신규 게임', '팔로우 게임'];
+  const handleClick = (item: string) => {
+    console.log(item);
+  }
 
   return (
     <StyledCategoryGamesWrapper>
       <StyleContain>
         <TitleCategory />
         <RecommendGames />
-        <FilterTap filterList={filterList} />
+        <FilterTap
+          onClickFilter={handleClick}
+          filterList={categoryFilterTab} 
+        />
         <GameList />
       </StyleContain>
     </StyledCategoryGamesWrapper>

--- a/client/src/pages/GameChannel.tsx
+++ b/client/src/pages/GameChannel.tsx
@@ -1,33 +1,36 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 import GameTitle from '../layouts/GameChannel/GameTitle';
 import FilterTap from '../components/common/FilterTap';
 import CreateChannelButton from '../components/ui/CreateChannelButton';
 import SelectTag from '../components/common/SelectTag';
 import PostList from '../layouts/GameChannel/PostList';
+import postOptionTags from '../data/postOptionTags';
+import { gameChannelFilterTab } from '../data/filterTapList';
 
 const GameChannel = ()  => {
 
-  const filterList = ['전체글', '인기순', '조회순', '최신순', '북마크 글', '내가 쓴 글'];
-  const optionsTag = [
-    { value: '전체', label: '전체' },
-    { value: '모집', label: '모집' },
-    { value: '공략', label: '공략' },
-    { value: '완료', label: '완료' },
-  ];
+  const { id } = useParams();
+  const [ isSelectTag, setIsSelectTag ] = useState<string>('전체');
+  const [ isSelectTab, setIsSelectTab ] = useState<string>(gameChannelFilterTab[0]);
 
   const handleChange = (value: string) => {
-    console.log(`selected ${value}`);
+    setIsSelectTag(value);
   };
 
+  const handleClick = (item: string) => {
+    setIsSelectTab(item);
+  }
+  
   return (
     <StyledGameChannelWrapper>
       <StyledGameChannelContain>
-        <GameTitle />
+        <GameTitle gameId={id} />
         <StyledMainContent>
         <StyledSubContent>
           <SelectTag 
-            options={optionsTag}
+            options={postOptionTags}
             onChange={handleChange}
           />
           <CreateChannelButton 
@@ -35,8 +38,15 @@ const GameChannel = ()  => {
             onClick={() => {console.log('게시글작성페이지로 이동')}}
           />
         </StyledSubContent>
-          <FilterTap filterList={filterList} />
-          <PostList />
+          <FilterTap
+            filterList={gameChannelFilterTab}
+            onClickFilter={handleClick}
+          />
+          <PostList 
+            gameId={id} 
+            isSelectTag={isSelectTag}
+            isSelectTab={isSelectTab}
+          />
         </StyledMainContent>
       </StyledGameChannelContain>
     </StyledGameChannelWrapper>

--- a/client/src/pages/GameChannel.tsx
+++ b/client/src/pages/GameChannel.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
-import { useParams } from 'react-router';
+import { useParams, useNavigate } from 'react-router';
 import styled from 'styled-components';
+import { useSelector } from 'react-redux';
+import { RootState } from '../store/store';
 import GameTitle from '../layouts/GameChannel/GameTitle';
 import FilterTap from '../components/common/FilterTap';
 import CreateChannelButton from '../components/ui/CreateChannelButton';
@@ -12,8 +14,10 @@ import { gameChannelFilterTab } from '../data/filterTapList';
 const GameChannel = ()  => {
 
   const { id } = useParams();
+  const navigate = useNavigate();
   const [ isSelectTag, setIsSelectTag ] = useState<string>('전체');
   const [ isSelectTab, setIsSelectTab ] = useState<string>(gameChannelFilterTab[0]);
+  const memberId = useSelector((state: RootState) => state.user.memberId);
 
   const handleChange = (value: string) => {
     setIsSelectTag(value);
@@ -21,8 +25,18 @@ const GameChannel = ()  => {
 
   const handleClick = (item: string) => {
     setIsSelectTab(item);
-  }
-  
+  };
+
+  const handleCreate = () => {
+    if (memberId === -1) {
+      navigate('/login');
+    } else {
+      // 게시글 작성페이지로 경로이동
+      // navigate('/');
+      console.log('게시글 작성페이지로 이동');
+    }
+  };
+
   return (
     <StyledGameChannelWrapper>
       <StyledGameChannelContain>
@@ -35,7 +49,7 @@ const GameChannel = ()  => {
           />
           <CreateChannelButton 
             text='게시글 작성' 
-            onClick={() => {console.log('게시글작성페이지로 이동')}}
+            onClick={handleCreate}
           />
         </StyledSubContent>
           <FilterTap

--- a/client/src/pages/GameChannel.tsx
+++ b/client/src/pages/GameChannel.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import { useParams, useNavigate } from 'react-router';
-import styled from 'styled-components';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { RootState } from '../store/store';
+import styled from 'styled-components';
 import GameTitle from '../layouts/GameChannel/GameTitle';
 import FilterTap from '../components/common/FilterTap';
 import CreateChannelButton from '../components/ui/CreateChannelButton';
@@ -11,13 +11,17 @@ import PostList from '../layouts/GameChannel/PostList';
 import postOptionTags from '../data/postOptionTags';
 import { gameChannelFilterTab } from '../data/filterTapList';
 
+// todo: 버튼 클릭시 경로 설정
+
 const GameChannel = ()  => {
 
-  const { id } = useParams();
+  const { gameId } = useParams();
+
   const navigate = useNavigate();
+  const memberId = useSelector((state: RootState) => state.user.memberId);
+
   const [ isSelectTag, setIsSelectTag ] = useState<string>('전체');
   const [ isSelectTab, setIsSelectTab ] = useState<string>(gameChannelFilterTab[0]);
-  const memberId = useSelector((state: RootState) => state.user.memberId);
 
   const handleChange = (value: string) => {
     setIsSelectTag(value);
@@ -40,7 +44,7 @@ const GameChannel = ()  => {
   return (
     <StyledGameChannelWrapper>
       <StyledGameChannelContain>
-        <GameTitle gameId={id} />
+        <GameTitle />
         <StyledMainContent>
         <StyledSubContent>
           <SelectTag 
@@ -57,7 +61,6 @@ const GameChannel = ()  => {
             onClickFilter={handleClick}
           />
           <PostList 
-            gameId={id} 
             isSelectTag={isSelectTag}
             isSelectTab={isSelectTab}
           />


### PR DESCRIPTION
## 추가 요청 및 작업 사항
- api로 데이터패칭을 할때 유저마다 게시글, 게임에 대한 팔로우 상태 처리에 대한 추가 데이터가 필요할 것 같습니다. (팔로우 기능에 대한 추가 수정필요)
- api로 북마크 글, 내가 쓴 글 get요청시 추천수, 조회수, 팔로우 상태에 대한 데이터가 빠져있어서 추가 데이터가 필요합니다.
- 현재 더미데이터로 데이터패칭하는 방식을 추후 api요청 방식으로 바꿀 예정입니다. (게임아이디에 따른 데이터패칭)
- 게시글 작성일 조회시 날짜의 출력 형태에 대해 같이 상의해야 할 것 같습니다. (몇 분전, 몇 일전 이런 형태 혹은 2023-05-12-시-분 형태 등..)

## 구현 완료된 기능
- 유저 로그인 상태에 따른 플로우 구분(북마크글, 내가쓴글 조회,게시글작성, 게임팔로우 시 경로 이동및 조회기능 구현)
- 필터링 기능 구현 (태그선택, 탭 선택시 각각 데이터리스트 필터링: 최신,인기,조회순)
- 페이지네이션 기능 구현 (페이지당 10개의 리스트 출력: 리액트 페이지네이션 라이브러리 사용)
- 게시글 클릭시 해당 상세 게시물로 이동 경로 연결