### PR TITLE
Fe feat/카테고리 페이지

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,7 +14,7 @@ const App = () => {
       <Routes>
         <Route path='/' element={<Template />}>
           <Route path='/' element={<Home />} />
-          <Route path='/category/:id' element={<CategoryGames />} />
+          <Route path='/categories/:categoryId' element={<CategoryGames />} />
           <Route path='/games/:gameId' element={<GameChannel />} />
           <Route path='/signup' element={<SignUp />} />
         </Route>

--- a/client/src/data/dummyCategories.ts
+++ b/client/src/data/dummyCategories.ts
@@ -3,19 +3,7 @@ type CategoryType = {
   categoryName: string;
 };
 
-export type Game = {
-  gameId: number;
-  gameName: string;
-  downloadUrl: string;
-  mainImgUrl: string;
-  categories: CategoryType[];
-};
-
-type Slide = {
-  key: number;
-  image: string;
-};
-
+// 모든 카테고리 조회 api 대체 api/categories
 export const dummyCategories : CategoryType[] = [
   {
     categoryId: 1,
@@ -29,99 +17,150 @@ export const dummyCategories : CategoryType[] = [
     categoryId: 3,
     categoryName: 'RPG'
   },
+  {
+    categoryId: 4,
+    categoryName: 'ACTION'
+  },
+  {
+    categoryId: 5,
+    categoryName: 'HORRER'
+  }
 ];
 
-export const dummyGameData : Game[] = [
-  {
-    gameId: 1,
-    gameName: '피파',
-    downloadUrl: 'downloadUrl',
-    mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/1000/435648-bcpdubiq-v4.webp',
-    categories: [
-      {
-        categoryId: 6,
-        categoryName: 'RPG'
-      },
-      {
-        categoryId: 7,
-        categoryName: '아케이드'
-      },
-      {
-        categoryId: 9,
-        categoryName: '호러'
-      },
-      {
-        categoryId: 10,
-        categoryName: '액션'
-      },
-      {
-        categoryId: 13,
-        categoryName: '카드'
-      },
-    ],
-  },
-  {
-    gameId: 2,
-    gameName: '던파',
-    downloadUrl: 'downloadUrl',
-    mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/1000/164227-f2fvqeih-v4.webp',
-    categories: [
-      {
-        categoryId: 1,
-        categoryName: 'FPS'
-      },
-      {
-        categoryId: 2,
-        categoryName: '힐링'
-      },
-      {
-        categoryId: 3,
-        categoryName: '공포'
-      }
-    ],
-  },
-  {
-    gameId: 3,
-    gameName: '리그오브레전드',
-    downloadUrl: 'downloadUrl',
-    mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/1000/348021-crop10_0_598_331-w5vedzau-v4.webp',
-    categories: [
-      {
-        categoryId: 1,
-        categoryName: 'AOBS'
-      },
-      {
-        categoryId: 2,
-        categoryName: '전략'
-      },
-      {
-        categoryId: 3,
-        categoryName: '시뮬레이션'
-      }
-    ],
-  },
-];
+// 특정 카테고리의 모든 게임 조회 더미- api/categories/{ctegory_id}/games
+// 데이터에 팔로우 수가 빠져있음 followerCount 데이터가 필요함
 
-export const slides : Slide[] = [
-  {
-    key: 0,
-    image: 'https://m.gjcdn.net/game-thumbnail/1000/435648-bcpdubiq-v4.webp'
-  },
-  {
-    key: 1,
-    image: 'https://m.gjcdn.net/game-thumbnail/1000/164227-f2fvqeih-v4.webp'
-  },
-  {
-    key: 2,
-    image:
-      'https://m.gjcdn.net/game-thumbnail/1000/348021-crop10_0_598_331-w5vedzau-v4.webp'
-  },
-  {
-    key: 3,
-    image: 'https://m.gjcdn.net/game-thumbnail/1000/352743-an4gjy3v-v4.webp'
-  },
-  {
-    key: 4,
-    image: 'https://m.gjcdn.net/game-thumbnail/1000/415163-pm6dqtkg-v4.webp'
-  },
-];
+export const dummyCategoriesGames = {
+  'data': [
+    {
+      gameId: 1,
+      gameName: '게임1',
+      downloadUrl: 'downloadUrl',
+      mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/1000/435648-bcpdubiq-v4.webp',
+      followerCount: 1,
+      categories: [
+        {
+          categoryId: 1,
+          categoryName: 'FPS'
+        },
+        {
+          categoryId: 2,
+          categoryName: 'SPORTS'
+        },
+        {
+          categoryId: 3,
+          categoryName: 'RPG'
+        },
+        {
+          categoryId: 4,
+          categoryName: 'ACTION'
+        },
+        {
+          categoryId: 5,
+          categoryName: 'HORRER'
+        },
+        {
+          categoryId: 6,
+          categoryName: 'COMIC'
+        }
+      ],
+    },
+    {
+      gameId: 2,
+      gameName: '게임2',
+      downloadUrl: 'downloadUrl',
+      mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/1000/164227-f2fvqeih-v4.webp',
+      followerCount: 2,
+      categories: [
+        {
+          categoryId: 1,
+          categoryName: 'FPS'
+        },
+        {
+          categoryId: 2,
+          categoryName: 'SPORTS'
+        },
+        {
+          categoryId: 3,
+          categoryName: 'RPG'
+        },
+      ],
+    },
+    {
+      gameId: 3,
+      gameName: '게임3',
+      downloadUrl: 'downloadUrl',
+      mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/1000/352743-an4gjy3v-v4.webp',
+      followerCount: 3,
+      categories: [
+        {
+          categoryId: 1,
+          categoryName: 'FPS'
+        },
+        {
+          categoryId: 4,
+          categoryName: 'ACTION'
+        },
+      ],
+    },
+    {
+      gameId: 4,
+      gameName: '게임4',
+      downloadUrl: 'downloadUrl',
+      mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/1000/348021-crop10_0_598_331-w5vedzau-v4.webp',
+      followerCount: 4,
+      categories: [
+        {
+          categoryId: 1,
+          categoryName: 'FPS'
+        },
+        {
+          categoryId: 4,
+          categoryName: 'ACTION'
+        },
+        {
+          categoryId: 5,
+          categoryName: 'HORRER'
+        }
+      ],
+    },
+    {
+      gameId: 5,
+      gameName: '게임5',
+      downloadUrl: 'downloadUrl',
+      mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/1000/415163-pm6dqtkg-v4.webp',
+      followerCount: 5,
+      categories: [
+        {
+          categoryId: 1,
+          categoryName: 'FPS'
+        },
+        {
+          categoryId: 4,
+          categoryName: 'ACTION'
+        },
+        {
+          categoryId: 5,
+          categoryName: 'HORRER'
+        }
+      ],
+    },
+    {
+      gameId: 6,
+      gameName: '게임6',
+      downloadUrl: 'downloadUrl',
+      mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/900/372753-weg49mcv-v4.webp',
+      followerCount: 6,
+      categories: [
+        {
+          categoryId: 1,
+          categoryName: 'FPS'
+        },
+        {
+          categoryId: 2,
+          categoryName: 'SPORTS'
+        },
+      ],
+    },
+  ]
+};

--- a/client/src/layouts/CategoryGames/GameItem.tsx
+++ b/client/src/layouts/CategoryGames/GameItem.tsx
@@ -1,36 +1,54 @@
 import React from 'react';
 import styled from 'styled-components';
 import CategoryTag from '../../components/common/CategoryTag';
-import { dummyGameData, Game } from '../../data/dummyCategories';
+import { dummyCategoriesGames } from '../../data/dummyCategories';
 import { Link } from 'react-router-dom';
 
-const GameItem = ({ gameId }: { gameId: number })  => {
+type CategoryType = {
+  categoryId: number,
+  categoryName: string,
+};
 
-  const game: Game | undefined = dummyGameData.find(item => item.gameId.toString() === gameId.toString());
-  const currentGameData = game?.categories ?? [];
-  const followNumber = 10; // 데이터패칭 해야됨 + 팔로우 기능추가 (버튼클릭시 텍스트변경)
+type Props = {
+  gameId: number, 
+  gameName: string,
+  followerCount: number,
+  categories: CategoryType[],
+  mainImgUrl: string,
+};
+
+const GameItem = ({ 
+  gameId, 
+  gameName, 
+  followerCount, 
+  categories,
+  mainImgUrl 
+}: Props)  => {
+
+  // todo: 팔로우 기능추가 (버튼클릭시 텍스트변경)
+  // 태그 색깔 통일 필요할듯
 
   const handleClick = () => {
     window.scrollTo(0, 0);
-  }
+  };
 
   return (
     <Link to={`/games/${gameId}`} onClick={handleClick}>
     <StyledItemWrapper >
-      <StyledImg src={game?.mainImgUrl} alt='game-image' />
+      <StyledImg src={mainImgUrl} alt='game-image' />
       <StyledTagContain>
       {
-        currentGameData.map((item, index) => (
+        categories.map((item, index) => (
           <CategoryTag 
             key={index}
             index={index}
             categoryName={item.categoryName}
           />
-        ))
+        )).slice(0, 5)
       }
       </StyledTagContain>
-      <StyledTitle>{game?.gameName}</StyledTitle>
-      <StyledFollow>팔로워: {followNumber}</StyledFollow>
+      <StyledTitle>{gameName}</StyledTitle>
+      <StyledFollow>팔로워: {followerCount}</StyledFollow>
     </StyledItemWrapper>
     </Link>
   );

--- a/client/src/layouts/CategoryGames/GameList.tsx
+++ b/client/src/layouts/CategoryGames/GameList.tsx
@@ -1,19 +1,75 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../store/store';
 import GameItem from './GameItem';
-import { dummyGameData } from '../../data/dummyCategories';
+import { dummyCategoriesGames } from '../../data/dummyCategories';
 
-const GameList = ()  => {
+interface Props {
+  isSelectTab: string;
+};
+
+const GameList: React.FC<Props> = ({ isSelectTab })  => {
+
+  // todo: 전체게임, 인기게임, 신규게임, 팔로우게임 필터링 조건 추가
+  // 전체데이터 받아올때 생성시간 데이터 추가가 필요함
+  // 조회는 무한스크롤
+  const { categoryId } = useParams<{ categoryId: string}>();
+  const memberId = useSelector((state: RootState) => state.user.memberId);
+
+  const filteredGames = dummyCategoriesGames.data
+    .filter((game) => game.categories.some((category) => category.categoryId.toString() === categoryId));
+  
+  const [ isFilteredGames, setIsFilteredGames ] = useState(filteredGames);
+  const [ userMessage, setUserMessage ] = useState('팔로우한 게임이 없습니다.');
+
+  useEffect(() => {
+    switch (isSelectTab) {
+      case '전체 게임':
+        // 채널 생성 시간 데이터 있어야됨
+        setIsFilteredGames(filteredGames);
+        break;
+      case '인기 게임':
+        setIsFilteredGames([...filteredGames].sort((a, b) => b.followerCount - a.followerCount))
+        break;
+      case '최신 게임':
+        // 채널 생성 시간 데이터 있어야됨
+        setIsFilteredGames(filteredGames);
+        break;
+      case '팔로우 게임':
+        // 팔로우 기능 구현시 데이터 추가하기
+        if (memberId === -1) {
+          setIsFilteredGames([]);
+          setUserMessage('로그인이 필요한 기능입니다.');
+        } else {
+          setIsFilteredGames([]);
+        }
+        break;
+      default:
+        setIsFilteredGames(filteredGames);
+        break;
+    }
+
+  }, [isSelectTab, memberId]);
 
   return (
     <StyledGameList>
       {
-        dummyGameData.map((item, index) => (
-          <GameItem 
-            key={item.gameId} 
+        isFilteredGames.length > 0 ?
+        isFilteredGames.map((item, index) => (
+          <GameItem
+            key={item.gameId}
             gameId={item.gameId}
+            gameName={item.gameName}
+            followerCount={item.followerCount}
+            categories={item.categories}
+            mainImgUrl={item.mainImgUrl}
           />
-        ))
+        )) : 
+        <StyledEmptyItem>
+          {userMessage}
+        </StyledEmptyItem>
       }
     </StyledGameList>
   );
@@ -36,4 +92,15 @@ const StyledGameList = styled.div`
     flex-basis: 50%;
     padding: 50px 35px;
   }
+`;
+
+const StyledEmptyItem = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 50px 0px;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--default-text-color);
 `;

--- a/client/src/layouts/CategoryGames/TitleCategory.tsx
+++ b/client/src/layouts/CategoryGames/TitleCategory.tsx
@@ -1,18 +1,34 @@
 import React from 'react';
+import { useNavigate, useParams } from 'react-router';
 import styled from 'styled-components';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../store/store';
 import CreateChannelButton from '../../components/ui/CreateChannelButton';
 import { dummyCategories } from '../../data/dummyCategories';
 
 const TitleCategory: React.FC = ()  => {
 
-  /**
-   *  todo: 
-   *  1. 현재 URL경로의 카테고리 아이디로 필터링 하기 (필터링) - useParms
-   *  2. 채널생성 버튼 클릭시 로그인시에만 생성경로로 이동, 비로그인시엔 로그인페이지로 이동 (라우팅) - onClick이벤트
-   *  3. 상수 contant로 빼기 - 텍스트 메세지
-   */
+  // todo: 홈에서 카테고리 클릭시 카테고리정보 리덕스에 저장 후 사용하는 방식으로 구현
+  const { categoryId } = useParams();
+  const memberId = useSelector((state: RootState) => state.user.memberId);
+  const navigate = useNavigate();
 
-  const currentCategory: string = dummyCategories[0].categoryName;
+  const currentCategory = dummyCategories.find(item => item.categoryId.toString() === categoryId);
+  if (!currentCategory) {
+    // 카테고리가 없을때 404페이지로 이동
+    return <div>페이지를 찾을 수 없습니다.</div>
+  };
+
+  // todo: 페이지별 중복사용하는 핸들러 함수 모듈화 리팩토링하기
+  const handleCreate = () => {
+    if (memberId === -1) {
+      navigate('/login');
+    } else {
+      // 게시글 작성페이지로 경로이동
+      // navigate('/');
+      console.log('게시글 작성페이지로 이동');
+    };
+  };
 
   return (
     <StyledTitleWrapper>
@@ -20,18 +36,18 @@ const TitleCategory: React.FC = ()  => {
         <StyledTitle>
           <StyledTitleName>
             {
-              currentCategory
+              currentCategory.categoryName
             }
           </StyledTitleName>
           <StyledSubText>
             {
-              `${currentCategory} 장르의 다양한 게임 채널들을 살펴보세요!`
+              `${currentCategory.categoryName} 장르의 다양한 게임 채널들을 살펴보세요!`
             }
           </StyledSubText>
         </StyledTitle>
         <CreateChannelButton 
           text={'게임채널 추가'} 
-          onClick={() => console.log('로그인 시에만 게임등록 채널로 이동')}
+          onClick={handleCreate}
         />
       </StyledTitleContainer>
     </StyledTitleWrapper>

--- a/client/src/layouts/GameChannel/GameTitle.tsx
+++ b/client/src/layouts/GameChannel/GameTitle.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store/store';
 import styled from 'styled-components';
-import { dummyGameData } from '../../data/dummyCategories';
+import { dummyCategoriesGames } from '../../data/dummyCategories';
 import CategoryTag from '../../components/common/CategoryTag';
 import CreateChannelButton from '../../components/ui/CreateChannelButton';
 
@@ -15,15 +15,15 @@ const GameTitle = ()  => {
   const memberId = useSelector((state: RootState) => state.user.memberId);
 
   const navigate = useNavigate();
-  const game = dummyGameData.find(item => item.gameId.toString() === gameId);
-  const followNumber = 10; // 데이터패칭 해야됨 + 팔로우 기능추가 (버튼클릭시 텍스트변경)
+  const filteredGames = dummyCategoriesGames.data.find((item) => item.gameId.toString() === gameId);
+  const followNumber = filteredGames?.followerCount; // 팔로우 기능추가 (버튼클릭시 텍스트변경)
 
-  if (!game) {
+  if (!filteredGames) {
     // 게임이 없을때 404페이지로 변경
     return <div>게임을 찾을 수 없습니다.</div>
   }
 
-  const currentGameData = game.categories;
+  const currentGameData = filteredGames.categories;
 
   const handleFollow = () => {
     if (memberId === -1) {
@@ -36,11 +36,11 @@ const GameTitle = ()  => {
   return (
     <StyledTitleWrapper>
       <StlyedGameImg 
-        src={game.mainImgUrl}
+        src={filteredGames.mainImgUrl}
         alt='game-image'
       />
       <StyledGameName>
-        {game.gameName}
+        {filteredGames.gameName}
       </StyledGameName>
       <StyledTagContain>
       {

--- a/client/src/pages/CategoryGames.tsx
+++ b/client/src/pages/CategoryGames.tsx
@@ -8,9 +8,11 @@ import { categoryFilterTab } from '../data/filterTapList';
 
 const CategoryGames = () => {
 
+  const [ isSelectTab, setIsSelectTab ] = useState<string>(categoryFilterTab[0]);
+
   const handleClick = (item: string) => {
-    console.log(item);
-  }
+    setIsSelectTab(item);
+  };
 
   return (
     <StyledCategoryGamesWrapper>
@@ -21,7 +23,9 @@ const CategoryGames = () => {
           onClickFilter={handleClick}
           filterList={categoryFilterTab} 
         />
-        <GameList />
+        <GameList 
+          isSelectTab={isSelectTab}
+        />
       </StyleContain>
     </StyledCategoryGamesWrapper>
   );

--- a/client/src/types/propsTypes.ts
+++ b/client/src/types/propsTypes.ts
@@ -1,3 +1,5 @@
+import SwiperInstance from 'swiper';
+
 export type NavStateType = {
   setShow: React.Dispatch<React.SetStateAction<boolean>>;
   show: boolean;
@@ -6,4 +8,14 @@ export type MemberType = {
   src: string;
   name: string;
   type: 'Front-End' | 'Back-End';
+};
+
+export type SwiperBgType = {
+  backgroundImage: string;
+};
+
+export type SwiperInfoType = {
+  introduceMode: boolean;
+  isLastCurrent: boolean;
+  currentSlideIndex: number;
 };


### PR DESCRIPTION
## 추가 요구 및 변동사항
- 각 카테고리 페이지에서 해당 카테고리의 게임들을 조회할때, 데이터에 게임채널이 생성된 시간이 추가되어야 할 것 같습니다. (필터링 기능에 필요함-최신순 조회할때)
- 각 카테고리 페이지에서 해당 카테고리의 게임들을 조회할때, 데이터에 팔로우 카운터도 필요할 것 같습니다.
- 홈에서 카테고리 클릭시 해당 카테고리의 정보를 리덕스에 저장 후 사용하는 방식으로 구현하기로 상의했습니다.
- 우선순위는 낮지만, 카테고리마다 고유의 UI 태그 색깔 통일이 필요할것 같습니다.