### PR TITLE
Fe feat/게임채널

### DIFF
--- a/client/src/components/CategoryGames/GameList.tsx
+++ b/client/src/components/CategoryGames/GameList.tsx
@@ -6,14 +6,15 @@ import Pagination from 'react-js-pagination';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store/store';
 import GameItem from './GameItem';
-import { type CategoryGameType } from '../../types/dataTypes';
+import { type GameType } from '../../types/dataTypes';
 import { type TabSelectType } from '../../types/propsTypes';
+import { dummyGamesData } from '../../data/dummyCategories';
 
 const GameList: React.FC<TabSelectType> = ({ isSelectTab })  => {
 
   const { categoryId } = useParams<{ categoryId: string}>();
   const memberId = useSelector((state: RootState) => state.user.memberId);
-  const [ isFilteredGames, setIsFilteredGames ] = useState<CategoryGameType[]>([]);
+  const [ isFilteredGames, setIsFilteredGames ] = useState<GameType[]>([]);
   const [ userMessage, setUserMessage ] = useState('등록된 게임채널이 없습니다.');
   const [ isPage, setPage ] = useState<number>(1);
   const [ isSize, setSize ] = useState<number>(0);
@@ -28,6 +29,7 @@ const GameList: React.FC<TabSelectType> = ({ isSelectTab })  => {
         switch (isSelectTab) {
           case '전체 게임': {
             const res = await axios.get(apiUrl);
+            
             const gamesData = res.data.data.sort((a: { createdAt: string }, b: { createdAt: string }) => 
               new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());  
             const pageInfo = res.data.pageInfo;
@@ -100,6 +102,7 @@ const GameList: React.FC<TabSelectType> = ({ isSelectTab })  => {
     };
 
     fetchGamesData();
+
   }, [isSelectTab, memberId, isPage]);
 
   const handlePageChange = (pageNumber: number) => {

--- a/client/src/components/CategoryGames/RecommendGames.tsx
+++ b/client/src/components/CategoryGames/RecommendGames.tsx
@@ -6,7 +6,6 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import { Autoplay, FreeMode, Pagination, EffectCoverflow } from 'swiper';
 import PATH_URL from '../../constants/pathUrl';
 import { BANNER_MESSAGE } from '../../constants/stringMessage';
-import { dummyGamesData } from '../../data/dummyCategories';
 import { type CategoryGameType } from '../../types/dataTypes';
 import { type SwiperBgType, type SwiperInfoType } from '../../types/propsTypes';
 import 'swiper/css';
@@ -28,44 +27,40 @@ const RecommedGames = () => {
   useEffect(() => {
     const fetchGamesData = async () => {
       try {
-        const res = await axios.get(`${process.env.REACT_APP_API_URL}/api/categories/${categoryId}/games`);
+        const res = await axios.get(
+        `${process.env.REACT_APP_API_URL}/api/categories/${categoryId}/games?page=${1}&filter=POPULAR`
+        );
         const gamesData = res.data.data;
-        // 더미데이터 테스트 코드
-        // const gamesData = dummyGamesData.data;
-        if (gamesData) {
-          const filteredGames = gamesData
-            .filter((game: { followerCount: number }) => game.followerCount >= 5)
-            .sort((a: { followerCount: number }, b: { followerCount: number }) => b.followerCount - a.followerCount)
-            .slice(0, 5);
-
-          isCurrentSlide(filteredGames[currentSlideIndex]);
-          setGamesList(filteredGames);
-          
-          if (currentSlideIndex === 0) {
-            setIntroduceMode(true);
-            setIsLastCurrent(false);
-            setCurrentText(BANNER_MESSAGE.FRONT);
-            return;
-          }
-          if (currentSlideIndex === filteredGames.length - 1) {
-            setIntroduceMode(true);
-            setIsLastCurrent(true);
-            setCurrentText(BANNER_MESSAGE.LAST);
-            return;
-          }
-          setIntroduceMode(false);
-          setIsLastCurrent(false);
-        } else {
-          // todo: 404페이지 경로로 이동 시키기
-          // return navigate('/');
-        }
+        setGamesList(gamesData);
       } catch (error) {
-        console.error(error);
-      }
+        console.log(error);
+      };
     };
-
     fetchGamesData();
-  }, [categoryId, currentSlide, currentSlideIndex]);
+  }, [categoryId]);
+
+  useEffect(() => {
+    const filteredGames = gamesList
+      .sort((a: { followerCount: number }, b: { followerCount: number }) => b.followerCount - a.followerCount)
+      .slice(0, 5);
+  
+    isCurrentSlide(filteredGames[currentSlideIndex]);
+  
+    if (currentSlideIndex === 0) {
+      setIntroduceMode(true);
+      setIsLastCurrent(false);
+      setCurrentText(BANNER_MESSAGE.FRONT);
+      return;
+    }
+    if (currentSlideIndex === filteredGames.length - 1) {
+      setIntroduceMode(true);
+      setIsLastCurrent(true);
+      setCurrentText(BANNER_MESSAGE.LAST);
+      return;
+    }
+    setIntroduceMode(false);
+    setIsLastCurrent(false);
+  }, [currentSlideIndex, gamesList]);
 
   const handleSlideChange = (swiper: any) => {
     setCurrentSlideIndex(swiper.activeIndex);

--- a/client/src/components/CategoryGames/RecommendGames.tsx
+++ b/client/src/components/CategoryGames/RecommendGames.tsx
@@ -6,7 +6,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import { Autoplay, FreeMode, Pagination, EffectCoverflow } from 'swiper';
 import PATH_URL from '../../constants/pathUrl';
 import { BANNER_MESSAGE } from '../../constants/stringMessage';
-import { type CategoryGameType } from '../../types/dataTypes';
+import { type GameType } from '../../types/dataTypes';
 import { type SwiperBgType, type SwiperInfoType } from '../../types/propsTypes';
 import 'swiper/css';
 import 'swiper/css/free-mode';
@@ -21,8 +21,8 @@ const RecommedGames = () => {
   const [ currentText, setCurrentText ] = useState('');
   const [ introduceMode, setIntroduceMode ] = useState(false);
   const [ isLastCurrent, setIsLastCurrent ] = useState(false);
-  const [ gamesList, setGamesList ] = useState<CategoryGameType[]>([]);
-  const [ currentSlide, isCurrentSlide ] = useState<CategoryGameType | undefined>(undefined);
+  const [ gamesList, setGamesList ] = useState<GameType[]>([]);
+  const [ currentSlide, isCurrentSlide ] = useState<GameType | undefined>(undefined);
 
   useEffect(() => {
     const fetchGamesData = async () => {

--- a/client/src/components/CategoryGames/TitleCategory.tsx
+++ b/client/src/components/CategoryGames/TitleCategory.tsx
@@ -5,16 +5,15 @@ import axios from 'axios';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store/store';
 import CreateChannelButton from '../ui/CreateChannelButton';
+import categoryData from '../../data/categoryData';
 
 const TitleCategory: React.FC = ()  => {
 
-  // 리팩토링 고민: 홈에서 카테고리 클릭시 카테고리정보 리덕스에 저장 후 사용하는 방식으로 구현
-  const [ isCurrentCategory, setIsCurrentCategory ] = useState();
+  const [ isCurrentCategory, setIsCurrentCategory ] = useState<string>();
   const { categoryId } = useParams<{ categoryId: string }>();
   const memberId = useSelector((state: RootState) => state.user.memberId);
   const navigate = useNavigate();
 
-  // 모든 카테고리 api 사용해서 현재 카테고리의 정보 가져옴
   useEffect(() => {
     (async () => {
       try {
@@ -23,7 +22,8 @@ const TitleCategory: React.FC = ()  => {
         const currentCategory = catrgoriesData.find((item: any) => item.categoryId.toString() === categoryId)?.categoryName;
 
         if (currentCategory) {
-          setIsCurrentCategory(currentCategory);
+          const mappingCategoryName = categoryData[currentCategory];
+          setIsCurrentCategory(mappingCategoryName.text);
         } else {
           // todo: 404페이지 경로로 이동 시키기
           // return navigate('/');
@@ -33,9 +33,6 @@ const TitleCategory: React.FC = ()  => {
       }
     })();
   }, [categoryId]);
-
-  // 더미데이터 테스트 코드
-  // const isCurrentCategory = dummyCategories.find(item => item.categoryId.toString() === categoryId)?.categoryName;
 
   // 리팩토링 고민: 페이지별 중복사용하는 핸들러 함수 모듈화 리팩토링하기
   const handleCreate = () => {

--- a/client/src/components/CategoryGames/TitleCategory.tsx
+++ b/client/src/components/CategoryGames/TitleCategory.tsx
@@ -5,7 +5,6 @@ import axios from 'axios';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store/store';
 import CreateChannelButton from '../ui/CreateChannelButton';
-import { dummyCategories } from '../../data/dummyCategories';
 
 const TitleCategory: React.FC = ()  => {
 

--- a/client/src/components/GameChannel/GameTitle.tsx
+++ b/client/src/components/GameChannel/GameTitle.tsx
@@ -1,66 +1,129 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import axios from 'axios';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store/store';
 import styled from 'styled-components';
-import { dummyGamesData } from '../../data/dummyCategories';
+import Loading from '../common/Loading';
+import { type GameType } from '../../types/dataTypes';
 import CategoryTag from '../common/CategoryTag';
 import CreateChannelButton from '../ui/CreateChannelButton';
-
-// todo: 게임 팔로우 기능 추가, 게임아이디에 맞게 게임 데이터 패칭, 경로 쿼리 재설정
+import PATH_URL from '../../constants/pathUrl';
 
 const GameTitle = ()  => {
   
   const { gameId } = useParams();
+  const navigate = useNavigate();
   const memberId = useSelector((state: RootState) => state.user.memberId);
 
-  const navigate = useNavigate();
-  const filteredGames = dummyGamesData.data.find((item) => item.gameId.toString() === gameId);
-  const followNumber = filteredGames?.followerCount; // 팔로우 기능추가 (버튼클릭시 텍스트변경)
+  const [ isGameData, setIsGameData ] = useState<GameType | null>(null);
+  const [ loading, setLoading ] = useState(true);
+  const [ isFollowed, setIsFollowed ] = useState(false);
 
-  if (!filteredGames) {
-    // 게임이 없을때 404페이지로 변경
+  useEffect(() => {
+    const fetchGameData = async () => {
+      try {
+      const res = await axios.get(`${process.env.REACT_APP_API_URL}/api/games/${gameId}`);
+      const gameData = res.data.data;
+      setIsGameData(gameData);
+      } catch (error) {
+        console.log(error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchGameData();
+  }, [gameId, isFollowed]);
+
+  useEffect(() => {
+    const fetchFollowerData = async () => {
+      try {
+        const res = await axios.get(`${process.env.REACT_APP_API_URL}/api/members/${memberId}/mygame`);
+        const followedData = res.data.data;
+        setIsFollowed(followedData.some((game: any) => game.gameId.toString() === gameId));
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    fetchFollowerData();
+  }, [memberId]);
+
+  if (loading) {
+    return <Loading />
+  };
+
+  if (!isGameData) {
+    // 404페이지로 이동하기
     return <div>게임을 찾을 수 없습니다.</div>
-  }
-
-  const currentGameData = filteredGames.categories;
+  };
 
   const handleFollow = () => {
     if (memberId === -1) {
       navigate('/login');
     } else {
-      console.log('게임 팔로우 기능 추가');
-    }
-  }
+      const token = localStorage.getItem('access_token');
+      console.log(token);
+
+      if (isFollowed) {
+        axios.delete(`${process.env.REACT_APP_API_URL}/api/games/${gameId}/unfollow`, {
+          headers: {
+            Authorization: `${token}`
+          }
+        })
+          .then(response => {
+            console.log('언팔로우 요청 성공');
+            setIsFollowed(false);
+          })
+          .catch(error => {
+            console.error('언팔로우 요청 실패:', error);
+          })
+      }
+      if (!isFollowed) {
+        axios.post(`${process.env.REACT_APP_API_URL}/api/games/${gameId}/follow`, {
+          headers: {
+            Authorization: `${token}`
+          }
+        })
+        .then(response => {
+          console.log('팔로우 요청 성공');
+          setIsFollowed(true);
+        })
+        .catch(error => {
+          console.error('팔로우 요청 실패:', error);
+        });
+      }
+    };
+  };
 
   return (
     <StyledTitleWrapper>
       <StlyedGameImg 
-        src={filteredGames.mainImgUrl}
+        src={isGameData?.mainImgUrl}
         alt='game-image'
       />
       <StyledGameName>
-        {filteredGames.gameName}
+        {isGameData?.gameName}
       </StyledGameName>
       <StyledTagContain>
       {
-        currentGameData.map((item, index) => (
-          <CategoryTag 
-            key={index}
-            categoryId={index}
-            categoryName={item.categoryName}
-          />
+        isGameData?.categories?.map((item, index) => (
+          <Link to={`${PATH_URL.CATEGORY}${item.categoryId}`} key={index}>
+            <CategoryTag
+              categoryId={item.categoryId}
+              categoryName={item.categoryName}
+            />
+          </Link>
         ))
       }
       </StyledTagContain>
       <StyledFollowContain>
-      <Link to={`/games/${gameId}/follower`} >
-        <StyledFollowNumber>
-          게임 팔로워: {followNumber}
-        </StyledFollowNumber>
-      </Link>
+        <Link to={`${PATH_URL.GAME}${gameId}/follower`} >
+          <StyledFollowNumber>
+            게임 팔로워: {isGameData?.followerCount}
+          </StyledFollowNumber>
+        </Link>
         <CreateChannelButton 
-          text='게임 팔로우' 
+          text={isFollowed ? '팔로우 취소' : '게임 팔로우'} 
           onClick={handleFollow}
         />
       </StyledFollowContain>
@@ -105,9 +168,13 @@ const StyledTagContain = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
+  padding-top: 10px;
   gap: 10px;
   width: 100%;
   flex-wrap: wrap;
+  & > a {
+    margin-bottom: 20px;
+  };
 `;
 
 const StyledFollowContain = styled.div`
@@ -117,7 +184,7 @@ const StyledFollowContain = styled.div`
   align-items: center;
   gap: 15%;
   width: 100%;
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 600;
   color: var(--cyan-dark-800);
   word-break: keep-all;

--- a/client/src/components/GameChannel/PostItem.tsx
+++ b/client/src/components/GameChannel/PostItem.tsx
@@ -1,33 +1,34 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import axios from 'axios';
 import styled from 'styled-components';
 import CategoryTag from '../common/CategoryTag';
-import { Post } from '../../data/dummyPostList';
+import { type GamePagePostType } from '../../types/dataTypes';
 import { StarTwoTone } from '@ant-design/icons';
 import PATH_URL from '../../constants/pathUrl';
+import { postOptionTags } from '../../data/postOptionTags';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../store/store';
 
 const PostItem = ({
   postId,
   title,
-  tag,
+  postTag,
   createdAt,
-  updatedAt,
-  view,
-  userName,
-  memberStatus,
+  views,
+  username,
   likeCount,
   commentCount
-}: Post)  => {
+}: GamePagePostType)  => {
+
+  // todo: 게시글 팔로우 조회기능추가- 해당 게시글을 북마크했는지 판단해서 불리언으로 별표시하기
+  // todo: 날짜 분, 시, 일, 년전, 제목 글자수 제한 ... 으로 바꾸기
 
   const { gameId } = useParams();
+  const memberId = useSelector((state: RootState) => state.user.memberId);
   const [ isMarked, setMarked ] = useState(false);
 
-  const handleMark = () => {
-    setMarked((prev) => !prev)
-  }
-
-  // todo: 게시글 팔로우 기능 추가, 날짜 분, 시, 일, 년전, 제목 글자수 제한 ... 으로 바꾸기, 경로 쿼리 재설정
-
+  /*
   const dateStr = createdAt;
   const date = new Date(dateStr);
   const year = date.getFullYear();
@@ -35,30 +36,32 @@ const PostItem = ({
   const day = date.getDate();
   const hour = date.getHours();
   const minute = date.getMinutes();
-
   const formattedDate = `${year}년 ${month}월 ${day}일 ${hour}시 ${minute}분`;
+  */
+  const tagId = postOptionTags.findIndex((option) => option.value === postTag);
 
   return (
-    <StyledWrapper>
-      <StyledContent>
-        <StyledFlexRow>
-        <Link to={`${PATH_URL.GAME}${gameId}/posts/${postId}`}>
-          <StyledTitle>
-            {title}
-          </StyledTitle>
-        </Link>
-          <CategoryTag categoryId={0} categoryName={tag} />
+    <Link to={`${PATH_URL.GAME}${gameId}/posts/${postId}`}>
+      <StyledWrapper>
+        <StyledContent>
+          <StyledFlexRow>
+            <StyledTitle>
+              {title}
+            </StyledTitle>
+            <CategoryTag categoryId={tagId} categoryName={postTag} />
         </StyledFlexRow>
         <StyledFlexRow>
           <StyledInfo>
             <StyledSpan>작성자:</StyledSpan>
-            {userName}
+            {username}
             <StyledSpan>작성일:</StyledSpan>
-            {formattedDate}
+            {/*
+              formattedDate
+            */}
             <StyledSpan>추천 수:</StyledSpan>
             {likeCount}
             <StyledSpan>조회 수:</StyledSpan>
-            {view}
+            {views}
           </StyledInfo>
         </StyledFlexRow>
       </StyledContent>
@@ -67,13 +70,13 @@ const PostItem = ({
         <StyledSpan>댓글:</StyledSpan>
         {commentCount}
         <StarTwoTone
-          onClick={handleMark}
           twoToneColor={ isMarked ? '#13A8A8'  : '#b4b4b4' }
-          style={{ fontSize: '20px' }}
+          style={{ fontSize: '15px' }}
         />
       </StyledInfo>
       </StyledFlexRow>
     </StyledWrapper>
+    </Link>
   );
 };
 

--- a/client/src/components/GameChannel/PostItem.tsx
+++ b/client/src/components/GameChannel/PostItem.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import CategoryTag from '../common/CategoryTag';
 import { Post } from '../../data/dummyPostList';
 import { StarTwoTone } from '@ant-design/icons';
+import PATH_URL from '../../constants/pathUrl';
 
 const PostItem = ({
   postId,
@@ -41,7 +42,7 @@ const PostItem = ({
     <StyledWrapper>
       <StyledContent>
         <StyledFlexRow>
-        <Link to={`/games/${gameId}/posts/${postId}`}>
+        <Link to={`${PATH_URL.GAME}${gameId}/posts/${postId}`}>
           <StyledTitle>
             {title}
           </StyledTitle>

--- a/client/src/components/GameChannel/PostList.tsx
+++ b/client/src/components/GameChannel/PostList.tsx
@@ -7,147 +7,164 @@ import Pagination from 'react-js-pagination';
 import styled from 'styled-components';
 import PostItem from './PostItem';
 import { type PostListProps } from '../../types/propsTypes';
-import {
-  dummyPostList,
-  dummyBookmarkList,
-  dummyMyList
-} from '../../data/dummyPostList';
+import { type GamePagePostType } from '../../types/dataTypes';
 
 const PostList: React.FC<PostListProps> = ({ isSelectTag, isSelectTab, isMappingTag }) => {
   const { gameId } = useParams();
   const memberId = useSelector((state: RootState) => state.user.memberId);
 
-  const [filteredPosts, setFilteredPosts] = useState(dummyPostList.post);
-  const [page, setPage] = useState(1);
-  const [userMessage, setUserMessage] = useState('작성된 게시글이 없습니다.');
+  const [ isFilteredPosts, setIsFilteredPosts ] = useState<GamePagePostType[]>([]);
+  const [ isUserMessage, setIsUserMessage ] = useState('작성된 게시글이 없습니다.');
 
-  const handlePageChange = (page: number) => {
-    setPage(page);
-  };
+  const [ isPage, setIsPage ] = useState<number>(1);
+  const [ isSize, setIsSize ] = useState<number>(0);
+  const [ isTotalSize, setIsTotalSize ] = useState<number>(0);
+
+  // todo: 내가 북마크한 게시글, 내가쓴 게시글 아직 필터링안됨, 태그선택시 요청 api처리 아직 안됨,
+  // 내가 북마크한 게시글 페이지네이션없이 받아지면 북마크상태값 조회도 처리가능
 
   useEffect(() => {
-    setPage(1);
-    setUserMessage('작성된 게시글이 없습니다.');
-    const postData = dummyPostList.post;
-    const bookmarkData = dummyBookmarkList.post;
-    const myPostData = dummyMyList.post;
+    const fetchPostsData = async () => {
+      try {
+        let apiUrl = `${process.env.REACT_APP_API_URL}/api/games/${gameId}/posts?page=${isPage}`;
 
-    switch (isSelectTab) {
-      case '최신순':
-        setFilteredPosts(
-          [...postData].sort(
-            (a, b) =>
-              new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-          )
-        );
-        break;
-      case '인기순':
-        setFilteredPosts(
-          [...postData].sort((a, b) => b.likeCount - a.likeCount)
-        );
-        break;
-      case '조회순':
-        setFilteredPosts([...postData].sort((a, b) => b.view - a.view));
-        break;
-      case '북마크 글':
-        if (memberId === -1) {
-          setFilteredPosts([]);
-          setUserMessage('로그인이 필요한 기능입니다.');
-        } else {
-          // 로그인 후 북마크한 글들을 가져오는 코드 작성
-          /* api 연결시 사용
-          axios.get(`${process.env.REACT_APP_API_URL}/api/members/${memberId}/bookmark`)
-            .then((response) => {
-              setFilteredPosts(response.data);
-            })
-            .catch((error) => {
-              console.error(error);
-            });
-          */
-          setFilteredPosts(
-            [...bookmarkData].sort(
-              (a, b) =>
-                new Date(b.createdAt).getTime() -
-                new Date(a.createdAt).getTime()
-            )
+        switch (isSelectTab) {
+          case '최신순': {
+            apiUrl += '&filter=NEW';
+            const res = await axios.get(apiUrl);
+            const currentPosts = res.data.data;
+            const pageInfo = res.data.pageInfo;
+
+            setIsFilteredPosts([...currentPosts]);
+            setIsSize(pageInfo.size);
+            setIsTotalSize(pageInfo.totalSize);
+            if (isFilteredPosts.length === 0) setIsUserMessage('작성된 게시글이 없습니다.');
+            break;
+          };
+          case '인기순': {
+            apiUrl += '&filter=LIKE';
+            const res = await axios.get(apiUrl);
+            const likePosts = res.data.data;
+            const pageInfo = res.data.pageInfo;
+
+            setIsFilteredPosts([...likePosts]);
+            setIsSize(pageInfo.size);
+            setIsTotalSize(pageInfo.totalSize);
+            if (isFilteredPosts.length === 0) setIsUserMessage('작성된 게시글이 없습니다.');
+            break;
+          };
+          case '조회순': {
+            apiUrl += '&filter=MOST_VIEWS';
+            const res = await axios.get(apiUrl);
+            const mostViewPosts = res.data.data;
+            const pageInfo = res.data.pageInfo;
+
+            setIsFilteredPosts([...mostViewPosts]);
+            setIsSize(pageInfo.size);
+            setIsTotalSize(pageInfo.totalSize);
+            if (isFilteredPosts.length === 0) setIsUserMessage('작성된 게시글이 없습니다.');
+            break;
+          };
+          case '북마크 글': {
+            if (memberId === -1) {
+              setIsFilteredPosts([]);
+              setIsUserMessage('로그인이 필요한 기능입니다.');
+            } else {
+              try {
+                const res = await axios.get(`${process.env.REACT_APP_API_URL}/api/members/${memberId}/bookmark`);
+                const getLikePosts = res.data.data;
+
+                if (getLikePosts.length > 0) {
+                  setIsFilteredPosts([...getLikePosts]);
+                } else {
+                  setIsFilteredPosts([]);
+                  setIsUserMessage('북마크한 게시글이 없습니다.');
+                };
+              } catch (error) {
+                console.log(error);  
+              }
+            }
+            break;
+          };
+          case '내가 쓴 글': {
+            if (memberId === -1) {
+              setIsFilteredPosts([]);
+              setIsUserMessage('로그인이 필요한 기능입니다.');
+            } else {
+              try {
+                const res = await axios.get(`${process.env.REACT_APP_API_URL}/api/members/${memberId}/mypost`);
+                const myPosts = res.data.data;
+
+                if (myPosts.length > 0) {
+                  setIsFilteredPosts([...myPosts]);
+                } else {
+                  setIsFilteredPosts([]);
+                  setIsUserMessage('북마크한 게시글이 없습니다.');
+                };
+              } catch (error) {
+                console.log(error);  
+              }
+            }
+            break;
+          }
+          default:
+            setIsFilteredPosts(isFilteredPosts);
+            break;
+          }
+
+          if (isSelectTag !== '전체') {
+            setIsFilteredPosts((prev) =>
+            prev.filter((post) => post.postTag === isSelectTag)
           );
         }
-        break;
-      case '내가 쓴 글':
-        if (memberId === -1) {
-          setFilteredPosts([]);
-          setUserMessage('로그인이 필요한 기능입니다.');
-        } else {
-          // 로그인 후 내가 쓴 글들을 가져오는 코드 작성
-          /* api 연결시 사용
-          axios.get(`${process.env.REACT_APP_API_URL}/api/members/${memberId}/mypost`)
-            .then((response) => {
-              setFilteredPosts(response.data);
-            })
-            .catch((error) => {
-              console.error(error);
-            });
-          */
-          setFilteredPosts(
-            [...myPostData].sort(
-              (a, b) =>
-                new Date(b.createdAt).getTime() -
-                new Date(a.createdAt).getTime()
-            )
-          );
-        }
-        break;
-      default:
-        setFilteredPosts(postData);
-        break;
-    }
+      } catch (error) {
+        console.log(error);
+      }
+    };
 
-    if (isSelectTag !== '전체') {
-      setFilteredPosts((prev) =>
-        prev.filter((post) => post.tag === isSelectTag)
-      );
-    }
-  }, [isSelectTab, isSelectTag, memberId]);
+    fetchPostsData();
 
-  const ITEMS_PER_PAGE = 10;
-  const lastIndex = page * ITEMS_PER_PAGE;
-  const firstIndex = lastIndex - ITEMS_PER_PAGE;
-  const currentPagePosts = filteredPosts.slice(firstIndex, lastIndex);
+  }, [isSelectTab, isSelectTag, memberId, isPage]);
 
-  console.log(isMappingTag);
+  const handlePageChange = (page: number) => {
+    setIsPage(page);
+  };
 
   return (
     <PostListWrapper>
-      {currentPagePosts.length > 0 ? (
-        currentPagePosts.map((post, index) => (
-          <PostItem
-            key={index}
-            postId={post.postId}
-            title={post.title}
-            tag={post.tag}
-            createdAt={post.createdAt}
-            updatedAt={post.updatedAt}
-            view={post.view}
-            userName={post.userName}
-            memberStatus={post.memberStatus}
-            likeCount={post.likeCount}
-            commentCount={post.commentCount}
-          />
-        ))
-      ) : (
-        <StyledEmptyItem>{userMessage}</StyledEmptyItem>
-      )}
-      <StyledPagination>
-        <Pagination
-          activePage={page}
-          itemsCountPerPage={10}
-          totalItemsCount={filteredPosts.length}
-          pageRangeDisplayed={5}
-          prevPageText={'‹'}
-          nextPageText={'›'}
-          onChange={handlePageChange}
-        />
-      </StyledPagination>
+      {
+        isFilteredPosts.length > 0 ? (
+          isFilteredPosts.map((post, index) => (
+            <PostItem
+              key={index}
+              postId={post.postId}
+              username={post?.member?.username}
+              title={post.title}
+              views={post.views}
+              postTag={post.postTag}
+              commentCount={post.commentCount}
+              likeCount={post.likeCount}
+              createdAt={post?.createdAt}
+            />
+          ))
+        ) : (
+          <StyledEmptyItem>{isUserMessage}</StyledEmptyItem>
+        )
+      }
+      {
+        isFilteredPosts.length > 0 &&
+          <StyledPagination>
+            <Pagination
+              activePage={isPage}
+              itemsCountPerPage={isSize}
+              totalItemsCount={isTotalSize}
+              pageRangeDisplayed={5}
+              prevPageText={'‹'}
+              nextPageText={'›'}
+              onChange={handlePageChange}
+            />
+          </StyledPagination>
+      }
     </PostListWrapper>
   );
 };
@@ -164,6 +181,7 @@ const PostListWrapper = styled.div`
 `;
 
 const StyledEmptyItem = styled.div`
+  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/client/src/components/GameChannel/PostList.tsx
+++ b/client/src/components/GameChannel/PostList.tsx
@@ -6,20 +6,14 @@ import { RootState } from '../../store/store';
 import Pagination from 'react-js-pagination';
 import styled from 'styled-components';
 import PostItem from './PostItem';
+import { type PostListProps } from '../../types/propsTypes';
 import {
   dummyPostList,
   dummyBookmarkList,
   dummyMyList
 } from '../../data/dummyPostList';
 
-interface Props {
-  isSelectTab: string;
-  isSelectTag: string;
-}
-
-// todo: 게임아이디에 맞게 게시글 데이터 패칭
-
-const PostList: React.FC<Props> = ({ isSelectTag, isSelectTab }) => {
+const PostList: React.FC<PostListProps> = ({ isSelectTag, isSelectTab, isMappingTag }) => {
   const { gameId } = useParams();
   const memberId = useSelector((state: RootState) => state.user.memberId);
 
@@ -119,6 +113,8 @@ const PostList: React.FC<Props> = ({ isSelectTag, isSelectTab }) => {
   const lastIndex = page * ITEMS_PER_PAGE;
   const firstIndex = lastIndex - ITEMS_PER_PAGE;
   const currentPagePosts = filteredPosts.slice(firstIndex, lastIndex);
+
+  console.log(isMappingTag);
 
   return (
     <PostListWrapper>

--- a/client/src/components/common/CategoryCard.tsx
+++ b/client/src/components/common/CategoryCard.tsx
@@ -4,6 +4,7 @@ import { CategoryType } from '../../types/dataTypes';
 import { Link } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { setCategory } from '../../slice/categorySlice';
+import PATH_URL from '../../constants/pathUrl';
 
 const CategoryCard = ({
   categoryId,
@@ -16,7 +17,7 @@ const CategoryCard = ({
     dispatch(setCategory({ categoryId, categoryName }));
   };
   return (
-    <Link to={`/category/${categoryId}`} onClick={onClickHandler}>
+    <Link to={`${PATH_URL.CATEGORY}${categoryId}`} onClick={onClickHandler}>
       <StyledContainer>
         {categoryIcon || <IoGameControllerOutline />}
         <StyledText>{categoryName}</StyledText>

--- a/client/src/components/common/Loading.tsx
+++ b/client/src/components/common/Loading.tsx
@@ -72,7 +72,6 @@ const StyledLoadingWrapper = styled.div`
   height: 100vh;
   display: grid;
   place-items: center;
-  background-color: var(--loding-bg);
   z-index: 9999;
 `;
 

--- a/client/src/constants/pathUrl.ts
+++ b/client/src/constants/pathUrl.ts
@@ -2,8 +2,8 @@ import { type PathUrlType } from '../types/dataTypes';
 
 const PATH_URL: PathUrlType = {
   HOME: '/',
-  CATEGORY: '/category/',
-  GAME: '/game/',
+  CATEGORY: '/categories/',
+  GAME: '/games/',
   POSTING: '/game/:gameId/post'
 };
 

--- a/client/src/constants/pathUrl.ts
+++ b/client/src/constants/pathUrl.ts
@@ -4,7 +4,7 @@ const PATH_URL: PathUrlType = {
   HOME: '/',
   CATEGORY: '/categories/',
   GAME: '/games/',
-  POSTING: '/game/:gameId/post'
+  POSTING: '/games/:gameId/posts'
 };
 
 export default PATH_URL;

--- a/client/src/data/categoryData.tsx
+++ b/client/src/data/categoryData.tsx
@@ -57,7 +57,7 @@ const iconData: IconType = {
   TURN_BASED: <GiEmptyChessboard />
 };
 
-const categoryText = {
+export const categoryText = {
   FPS: 'FPS',
   RPG: 'RPG',
   ADVENTURE: '어드벤쳐',

--- a/client/src/data/dummyCategories.ts
+++ b/client/src/data/dummyCategories.ts
@@ -1,112 +1,3 @@
-type CategoryType = {
-  categoryId: number;
-  categoryName: string;
-};
-
-// 모든 카테고리 조회 api 대체 api/categories
-export const dummyCategories : CategoryType[] = [
-  {
-    categoryId: 6,
-    categoryName: 'ACTION'
-  },
-  {
-    categoryId: 3,
-    categoryName: 'ADVENTURE'
-  },
-  {
-    categoryId: 9,
-    categoryName: 'CARD_AND_BOARD'
-  },
-  {
-    categoryId: 14,
-    categoryName: 'COMEDY'
-  },
-  {
-    categoryId: 1,
-    categoryName: 'FPS'
-  },
-  {
-    categoryId: 15,
-    categoryName: 'HACK_AND_SLASH'
-  },
-  {
-    categoryId: 12,
-    categoryName: 'HEALING'
-  },
-  {
-    categoryId: 13,
-    categoryName: 'HORROR'
-  },
-  {
-    categoryId: 23,
-    categoryName: 'MOBA'
-  },
-  {
-    categoryId: 24,
-    categoryName: 'MOBILE'
-  },
-  {
-    categoryId: 18,
-    categoryName: 'MULTIPLAYER'
-  },
-  {
-    categoryId: 25,
-    categoryName: 'OTHER'
-  },
-  {
-    categoryId: 20,
-    categoryName: 'PLATFORMER'
-  },
-  {
-    categoryId: 10,
-    categoryName: 'PUZZLE'
-  },
-  {
-    categoryId: 19,
-    categoryName: 'ROGUELIKE'
-  },
-  {
-    categoryId: 2,
-    categoryName: 'RPG'
-  },
-  {
-    categoryId: 4,
-    categoryName: 'SHOOTING'
-  },
-  {
-    categoryId: 5,
-    categoryName: 'SIMULATION'
-  },
-  {
-    categoryId: 7,
-    categoryName: 'SPORTS'
-  },
-  {
-    categoryId: 11,
-    categoryName: 'STORY'
-  },
-  {
-    categoryId: 8,
-    categoryName: 'STRATEGY'
-  },
-  {
-    categoryId: 17,
-    categoryName: 'SURVIVAL'
-  },
-  {
-    categoryId: 22,
-    categoryName: 'THREE_D_PLATFORMER'
-  },
-  {
-    categoryId: 16,
-    categoryName: 'TURN_BASED'
-  },
-  {
-    categoryId: 21,
-    categoryName: 'TWO_D_PLATFORMER'
-  }
-];
-
 // 특정 카테고리의 모든 게임 조회 더미- api/categories/{ctegory_id}/games
 export const dummyGamesData = {
   data: [
@@ -180,3 +71,87 @@ pageInfo: {
     totalPage: 1
   }
 }
+
+// 특정 게임 조회 더미- api/games/{game_id}
+export const dummyGameData = {
+  data: {
+    gameId: 1,
+    gameName: '한달전게임',
+    downloadUrl: 'download',
+    mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/1000/415163-pm6dqtkg-v4.webp',
+    categories: [
+      {
+          categoryId: 1,
+          categoryName: 'FPS'
+      },
+      {
+          'categoryId': 2,
+          'categoryName': 'RPG'
+      },
+      {
+        categoryId: 16,
+        categoryName: 'TURN_BASED'
+      },
+      {
+        categoryId: 21,
+        categoryName: 'TWO_D_PLATFORMER'
+      },
+    ],
+    followerCount: 30,
+    createdAt: '2023-03-01T18:38:39'
+  }
+};
+
+export const dummyFollowedGames = {
+  data: [
+    {
+      gameId: 3,
+      gameName: '한달전게임',
+      downloadUrl: 'download',
+      mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/1000/415163-pm6dqtkg-v4.webp',
+      categories: [
+        {
+            categoryId: 1,
+            categoryName: 'FPS'
+        },
+        {
+            'categoryId': 2,
+            'categoryName': 'RPG'
+        },
+        {
+          categoryId: 16,
+          categoryName: 'TURN_BASED'
+        },
+        {
+          categoryId: 21,
+          categoryName: 'TWO_D_PLATFORMER'
+        },
+      ],
+      followerCount: 30,
+      createdAt: '2023-03-01T18:38:39'
+    },
+    {
+      gameId: 1,
+      gameName: '두달전게임',
+      downloadUrl: 'download',
+      mainImgUrl: 'https://m.gjcdn.net/game-thumbnail/1000/415163-pm6dqtkg-v4.webp',
+      categories: [
+        {
+            categoryId: 1,
+            categoryName: 'FPS'
+        },
+        {
+          categoryId: 2,
+          categoryName: 'RPG'
+        },
+        {
+          categoryId: 16,
+          categoryName: 'TURN_BASED'
+        },
+      ],
+      followerCount: 30,
+      createdAt: '2023-03-01T18:38:39'
+    }
+  ]
+};
+

--- a/client/src/data/postOptionTags.ts
+++ b/client/src/data/postOptionTags.ts
@@ -1,11 +1,19 @@
-// 모집, 버그, 공략, 수다, 정보, 팬아트, 질문, 문의(건의), 자랑하기, 후기, 기타
+import { type PostOptinType, type OptionMapping } from '../types/dataTypes';
 
-type Option = {
-  value: string;
-  label: string;
-};
+/*
+RECRUITMENT("모집"),
+BUG("버그"),
+WALKTHROUGH("공략"),
+CHIT_CHAT("수다"),
+INFORMATION("정보"),
+FAN_ART("팬아트"),
+QUESTION("질문"),
+SHOWING_OFF("자랑하기"),
+REVIEW("리뷰"),
+ETC("기타");
+*/
 
-const postOptionTags: Option[] = [
+export const postOptionTags: PostOptinType[] = [
   { value: '전체', label: '전체' },
   { value: '모집', label: '모집' },
   { value: '버그', label: '버그' },
@@ -14,10 +22,23 @@ const postOptionTags: Option[] = [
   { value: '정보', label: '정보' },
   { value: '팬아트', label: '팬아트' },
   { value: '질문', label: '질문' },
-  { value: '문의', label: '문의' },
-  { value: '자랑', label: '자랑' },
-  { value: '후기', label: '후기' },
+  { value: '자랑하기', label: '자랑하기' },
+  { value: '리뷰', label: '리뷰' },
   { value: '기타', label: '기타' },
 ];
+
+export const optionMapping: OptionMapping = {
+  전체: 'ALL',
+  모집: 'RECRUITMENT',
+  버그: 'BUG',
+  공략: 'WALKTHROUGH',
+  수다: 'CHIT_CHAT',
+  정보: 'INFORMATION',
+  팬아트: 'FAN_ART',
+  질문: 'QUESTION',
+  자랑하기: 'SHOWING_OFF',
+  리뷰: 'REVIEW',
+  기타: 'ETC',
+};
 
 export default postOptionTags;

--- a/client/src/data/postOptionTags.ts
+++ b/client/src/data/postOptionTags.ts
@@ -1,4 +1,4 @@
-import { type PostOptinType, type OptionMapping } from '../types/dataTypes';
+import { type PostOptionType, type OptionMapping } from '../types/dataTypes';
 
 /*
 RECRUITMENT("모집"),
@@ -13,7 +13,7 @@ REVIEW("리뷰"),
 ETC("기타");
 */
 
-export const postOptionTags: PostOptinType[] = [
+export const postOptionTags: PostOptionType[] = [
   { value: '전체', label: '전체' },
   { value: '모집', label: '모집' },
   { value: '버그', label: '버그' },

--- a/client/src/pages/GameChannel.tsx
+++ b/client/src/pages/GameChannel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { RootState } from '../store/store';
 import styled from 'styled-components';
@@ -8,23 +8,23 @@ import FilterTap from '../components/common/FilterTap';
 import CreateChannelButton from '../components/ui/CreateChannelButton';
 import SelectTag from '../components/common/SelectTag';
 import PostList from '../components/GameChannel/PostList';
-import postOptionTags from '../data/postOptionTags';
+import { postOptionTags, optionMapping } from '../data/postOptionTags';
 import { gameChannelFilterTab } from '../data/filterTapList';
 
 // todo: 버튼 클릭시 경로 설정
 
 const GameChannel = ()  => {
 
-  const { gameId } = useParams();
-
   const navigate = useNavigate();
   const memberId = useSelector((state: RootState) => state.user.memberId);
 
   const [ isSelectTag, setIsSelectTag ] = useState<string>('전체');
   const [ isSelectTab, setIsSelectTab ] = useState<string>(gameChannelFilterTab[0]);
+  const [ isMappingTag, setIsMappingTag ] = useState<string>('');
 
   const handleChange = (value: string) => {
     setIsSelectTag(value);
+    setIsMappingTag(optionMapping[value]);
   };
 
   const handleClick = (item: string) => {
@@ -63,6 +63,7 @@ const GameChannel = ()  => {
           <PostList 
             isSelectTag={isSelectTag}
             isSelectTab={isSelectTab}
+            isMappingTag={isMappingTag}
           />
         </StyledMainContent>
       </StyledGameChannelContain>

--- a/client/src/types/dataTypes.ts
+++ b/client/src/types/dataTypes.ts
@@ -29,7 +29,9 @@ export type GameType = {
   mainImgUrl: string;
   followerCount: number;
   categories: CategoryType[];
+  createdAt?: string;
 };
+
 export type PageInfoType = {
   page: number;
   size: number;
@@ -37,18 +39,6 @@ export type PageInfoType = {
   totalPage: number;
 };
 
-export type CategoryGameType = {
-  gameId: number;
-  gameName: string;
-  downloadUrl: string;
-  mainImgUrl: string;
-  categories: {
-    categoryId: number;
-    categoryName: string;
-  }[];
-  followerCount: number;
-  createdAt: string;
-};
 export type PostType = {
   postTag: string;
   title: string;
@@ -60,4 +50,13 @@ export type PathUrlType = {
   CATEGORY: string;
   GAME: string;
   POSTING: string;
+};
+
+export type PostOptinType = {
+  value: string;
+  label: string;
+};
+
+export type OptionMapping = {
+  [key: string]: string;
 };

--- a/client/src/types/dataTypes.ts
+++ b/client/src/types/dataTypes.ts
@@ -52,11 +52,55 @@ export type PathUrlType = {
   POSTING: string;
 };
 
-export type PostOptinType = {
+export type PostOptionType = {
   value: string;
   label: string;
 };
 
 export type OptionMapping = {
   [key: string]: string;
+};
+
+/*
+특정게임의 게시글 전체 조회할때 받는 응답데이터의 타입
+member에 username은 작성자 이름이라 필요하고,
+
+유저 북마크게시글,
+내가쓴글 get데이터에 gameId가 있으면 특정게임내 페이지에서 필터링 가능할듯
+
+export type PostType = {
+  postId: number;
+  member: {
+    username: string;
+  };
+  title: string;
+  views: number;
+  postTag: string;
+  commentCount: number;
+  likeCount: number;
+  createdAt?: string;
+  gameId?: number;
+  username?: string;
+};
+*/
+
+export type GamePagePostType = {
+  postId: number;
+  member?: {
+    memberId?: number;
+    email?: string;
+    username: string;
+    imageUrl?: string;
+    followerCount?: number;
+    followingCount?: number;
+  };
+  title: string;
+  content?: string;
+  views: number;
+  postTag: string;
+  commentCount: number;
+  likeCount: number;
+  gameId?: number;
+  createdAt?: string;
+  username?: string;
 };

--- a/client/src/types/propsTypes.ts
+++ b/client/src/types/propsTypes.ts
@@ -25,13 +25,19 @@ export type TabSelectType = {
 };
 
 export type GameItemPropsType = {
-  gameId: number, 
-  gameName: string,
-  followerCount: number,
-  categories: CategoryType[],
-  mainImgUrl: string,
+  gameId: number;
+  gameName: string;
+  followerCount: number;
+  categories: CategoryType[];
+  mainImgUrl: string;
 }
 
 export type StyledTagPropsType = {
   styleId: number;
 };
+
+export type PostListProps = {
+  isSelectTab: string;
+  isSelectTag: string;
+  isMappingTag: string;
+}


### PR DESCRIPTION
## 추가 변동사항 및 api 요청 궁금점

- 로그인한 특정유저가 게임 팔로우 및 취소 요청시 전달할 값은 무엇인가요? (요청보낼때 헤더에 엑세스토큰 전달하면 되는지)

```ts
        axios.post(`${process.env.REACT_APP_API_URL}/api/games/${gameId}/follow`, {
          headers: {
            Authorization: `${token}`
          }
        })
```

현재 이런식으로 요청을 보내고있는데, axios두번째 전달할 data가 없을때, headers를 두번째 인자 자리에 위치 시켜도 될까요?

- 모든 포스트 태그 종류를 조회하는 get api가 필요하지 않을까요? (게임채널 페이지에서 사용자가 태그 선택해서 게시글 조회할때 사용할 태그들이 필요해요. - 지금은 data에 고정값으로 사용중)

- 회원 게시글 북마크 목록과 회원 내가 쓴 게시글 api가 없는것 같아요ㅜㅜ (api명세서엔 있는데 포스트맨에선 안보여요)

- 위 (게시글 북마크, 내가 쓴 게시글 조회) api를 응답받을때, gameId도 추가가 필요할것 같아요. (게임채널 페이지내에서 게임아이디로 필터링해야 될 것 같습니다.)

- 특정 게임내에 게시글을 조회하는 api에서 불필요한 데이터가 포함되있는 것 같아요. 그리고 createdAt값이 빠져있어요. (필요한 데이터값은 아래와 같습니다)

```ts
export type PostType = {
  postId: number;
  userName: string;
  title: string;
  views: number;
  postTag: string;
  commentCount: number;
  likeCount: number;
  createdAt: string;
  gameId: number;
 }
```

## 프론트 관련 궁금점

- 현재 memberId 값을 가지고 기능 구현을 한게 많은데, 로그인시에 해당 memberId값이 undefined로 찍히는것 같아요..?
(새로고침했을때 로그아웃되는 거랑 연관이 있는게 아닐까합니다)

-  새로고침시에 로그인상태가 풀리는데, 이 두가지 문제점을 해결하려면 자동 로그인 기능을 추가해야될 것 같아요

- 마찬가지로, 새로고침시에 리덕스에 저장된 카테고리 정보도 undefined가 떠서 로컬스토리지 저장을 고려해봐야할 것 같은데
만약 사용자가 홈에서 카테고리로 접속하지 않는 경우나 다른 경로로 접속할땐 어떻게 해결해야되나요?