### PR TITLE
Fe feat/마이페이지

### DIFF
--- a/client/src/AppRoutes.tsx
+++ b/client/src/AppRoutes.tsx
@@ -9,6 +9,7 @@ import LogIn from './pages/Login';
 import PATH_URL from './constants/pathUrl';
 import GameRegister from './pages/GameRegister';
 import Page404 from './components/common/404';
+import UserInfoPage from './pages/UserInfoPage';
 
 const AppRoutes = () => {
   return (
@@ -33,6 +34,7 @@ const AppRoutes = () => {
         <Route path={PATH_URL.REGISTER} element={<GameRegister />} />
         <Route path={PATH_URL.ERROR} element={<Page404 />} />
         <Route path={PATH_URL.NOTFOUND} element={<Page404 />} />
+        <Route path={`${PATH_URL.USER_INFO}:memberId`} element={<UserInfoPage />} />
       </Route>
     </Routes>
   );

--- a/client/src/components/UserInfo/UserAboutMe.tsx
+++ b/client/src/components/UserInfo/UserAboutMe.tsx
@@ -1,0 +1,50 @@
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+
+const UserAboutMe = () => {
+
+  const [ isAboutMeText, setIsAboutMeText ] = useState<string>('');
+  const { memberId } = useParams();
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        const res = await axios.get(`${process.env.REACT_APP_API_URL}/api/members/${memberId}/profile`);
+        const fetchedAboutMe = res.data.data.aboutMe;
+        setIsAboutMeText(fetchedAboutMe);
+
+      } catch (error) {
+        console.log(error);
+      };
+    };
+
+    fetchUserData();
+  } , [memberId]);
+
+  if (isAboutMeText === null) {
+    setIsAboutMeText('아직 작성한 소개글이 없습니다.');
+  };
+
+  return (
+    <StyledWrapper>
+      { isAboutMeText }
+    </StyledWrapper>
+  );
+};
+
+export default UserAboutMe;
+
+const StyledWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 300px;
+  background-color: #fff;
+  box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
+  padding: 50px;
+  border-radius: 15px;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+`;

--- a/client/src/components/UserInfo/UserActions.tsx
+++ b/client/src/components/UserInfo/UserActions.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import styled from 'styled-components';
+import CreateChannelButton from '../ui/CreateChannelButton';
+import { TbMessages } from 'react-icons/tb';
+import PATH_URL from '../../constants/pathUrl';
+
+const UserProfileAction = () => {
+
+  const [ isSameUser, setIsSameUser ] = useState<boolean>(false);
+  const [ isFollowed, setIsFollowed ] = useState(false);
+  const [ loginedId, setIsLoginedId ] = useState<string>();
+
+  const { memberId } = useParams();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchFollowerData = async () => {
+      const getMemberData = localStorage.getItem('user');
+      const memberData = getMemberData ? JSON.parse(getMemberData) : { memberId: -1 };
+      const loginId = memberData.memberId;
+
+      if (loginId.toString() === memberId) {
+        setIsSameUser(true);
+      };
+  
+      setIsLoginedId(loginId);
+
+      try {
+        const res = await axios.get(
+          `${process.env.REACT_APP_API_URL}/api/members/${loginId}/following`
+        );
+        const followedData = res.data.data;
+
+        setIsFollowed(
+          followedData.some((user: any) => user.memberId.toString() === memberId)
+        );
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    fetchFollowerData();
+  } , [memberId]);
+
+  const handleEditProfile = () => {
+    // todo: 프로필 수정 페이지로 이동하기
+    console.log('프로필 수정 페이지로 이동');
+  };
+  
+  const handleFollow = () => {
+    if (Number(loginedId) === -1) {
+      navigate(`${PATH_URL.LOGIN}`);
+    } else {
+      const token = localStorage.getItem('access_token');
+      if (isFollowed) {
+        axios
+          .delete(
+            `${process.env.REACT_APP_API_URL}/api/members/${memberId}/unfollow`,
+              {
+                headers: {
+                  Authorization: `${token}`
+                }
+              }
+          )
+          .then((response) => {
+            setIsFollowed(false);
+          })
+          .catch((error) => {
+            console.error('언팔로우 요청 실패:', error);
+          });
+        }
+      if (!isFollowed) {
+        axios.post(`${process.env.REACT_APP_API_URL}/api/members/${memberId}/follow`, {}, {
+          headers: {
+            Authorization: `${token}`
+          }
+        })
+        .then(response => {
+          setIsFollowed(true);
+        })
+        .catch(error => {
+          console.error('팔로우 요청 실패:', error);
+        });
+      }
+    }
+  };
+  
+  const handleMessage = () => {
+    // todo: 해당 유저와 채팅창으로 이동하기
+    console.log('해당 유저와 채팅창으로 이동');
+  };
+
+  return (
+    <StyledWrapper>
+      {isSameUser ? (
+        <CreateChannelButton onClick={handleEditProfile} text={'프로필 수정하기'} />
+      ) : (
+        <>
+          <CreateChannelButton onClick={handleFollow} text={isFollowed ? '팔로우 취소' : '팔로우 하기'} />
+          <StyledMessageContain>
+            <TbMessages
+              onClick={handleMessage} 
+            />
+          </StyledMessageContain>
+        </>
+      )}
+    </StyledWrapper>
+  );
+};
+
+export default UserProfileAction;
+
+
+const StyledWrapper = styled.div`
+  margin-top: 10px;
+  display: flex;
+  gap: 30px;
+  align-items: center;
+`;
+
+const StyledMessageContain = styled.div`
+  color: var(--cyan-dark-800);
+  font-size: 35px;
+  &:hover {
+    color: var(--button-inactive-color);
+  }
+`;

--- a/client/src/components/UserInfo/UserProfileImg.tsx
+++ b/client/src/components/UserInfo/UserProfileImg.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import { StyledUserImgType } from '../../types/propsTypes';
+
+const UserProfileImg = ({ isUserImg }: { isUserImg: string }) => {
+
+  return (
+    <StyledWrapper getUserImg={isUserImg} />
+  );
+};
+
+export default UserProfileImg;
+
+const StyledWrapper = styled.div<StyledUserImgType>`
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  background:
+    url(${(props) => props.getUserImg});
+  box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+`;

--- a/client/src/components/UserInfo/UserProfileName.tsx
+++ b/client/src/components/UserInfo/UserProfileName.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+
+const UserProfileName = ({ isUserName, isUserEmail } : { isUserName: string, isUserEmail: string }) => {
+
+  const [ isSameUser, setIsSameUser ] = useState<boolean>(false);
+  const { memberId } = useParams();
+
+  useEffect(() => {
+    const getMemberData = localStorage.getItem('user');
+    const memberData = getMemberData ? JSON.parse(getMemberData) : { memberId: -1 };
+    const loginId = memberData.memberId;
+
+    if (loginId.toString() === memberId) {
+      setIsSameUser(true);
+    };
+
+  } , [memberId]);
+
+  return (
+    <StyledWrapper>
+      {isUserName}
+      <StyledEmail>
+        {isSameUser && isUserEmail}
+      </StyledEmail>
+    </StyledWrapper>
+  );
+};
+
+export default UserProfileName;
+
+
+const StyledWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  font-size: 16px;
+  margin-top: 10px;
+  gap: 10px;
+  width: 300px;
+`;
+
+const StyledEmail = styled.p`
+  font-size: 14px;
+  color: var(--cyan-light-700);
+  word-break: keep-all;
+  overflow-wrap: break-word;
+`;

--- a/client/src/components/UserInfo/UserTitle.tsx
+++ b/client/src/components/UserInfo/UserTitle.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import axios from 'axios';
+import UserProfileImg from './UserProfileImg';
+import UserProfileName from './UserProfileName';
+import UserAboutMe from './UserAboutMe';
+import UserProfileAction from './UserActions';
+import Loading from '../common/Loading';
+
+const UserTitle = () => {
+
+ const { memberId } = useParams();
+
+  const [ isUserImg, setIsUserImg ] = useState<string>('');
+  const [ isUserName, setIsUserName ] = useState<string>('');
+  const [ isUserEmail, setIsUserEmail ] = useState<string>('');
+  const [ loading, setLoading ] = useState(true);
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        const res = await axios.get(`${process.env.REACT_APP_API_URL}/api/members/${memberId}/profile`);
+        const fetchedData = res.data.data;
+
+        setIsUserImg(fetchedData.imageUrl);
+        setIsUserName(fetchedData.userName);
+        setIsUserEmail(fetchedData.email);
+
+      } catch (error) {
+        console.log(error);
+      } finally {
+        setLoading(false);
+      };
+    };
+
+    fetchUserData();
+  } , [memberId]);
+
+  if (loading) {
+    return <Loading />;
+  };
+
+  if (isUserName === null) {
+    setIsUserName('등록된 닉네임이 없습니다.');
+  };
+
+  return (
+    <StyledTitleWrapper>
+      <UserProfileImg isUserImg={isUserImg} />
+      <UserProfileName isUserName={isUserName} isUserEmail={isUserEmail} />
+      <UserProfileAction />
+      <StyledAboutMe>
+        <UserAboutMe />
+      </StyledAboutMe>
+    </StyledTitleWrapper>
+  );
+};
+
+export default UserTitle;
+
+const StyledTitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 30px;
+  box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
+  @media screen and (max-width: 650px) {
+    width: 100%;
+  }
+`;
+
+const StyledAboutMe = styled.div`
+  @media screen and (max-width: 650px) {
+    display: none;
+  }
+`;

--- a/client/src/constants/pathUrl.ts
+++ b/client/src/constants/pathUrl.ts
@@ -10,7 +10,8 @@ const PATH_URL: PathUrlType = {
   POSTING: '/posts',
   EDIT: '/edit',
   ERROR: '/error',
-  NOTFOUND: '*'
+  NOTFOUND: '*',
+  USER_INFO: '/users/',
 };
 
 export default PATH_URL;

--- a/client/src/layouts/Header/Header.tsx
+++ b/client/src/layouts/Header/Header.tsx
@@ -19,7 +19,7 @@ const Header = ({ setShow, show }: NavStateType) => {
         <Logo />
         <SearchBar />
       </StyledResponsiveContainer>
-      {user.memberId !== -1 ? <UserBtn /> : <HeaderBtnContainer />}
+      {user.memberId !== -1 ? <UserBtn memberId={user.memberId} /> : <HeaderBtnContainer />}
     </StyledContainer>
   );
 };

--- a/client/src/layouts/Header/UserBtn.tsx
+++ b/client/src/layouts/Header/UserBtn.tsx
@@ -1,11 +1,13 @@
 import styled from 'styled-components';
 import { AiOutlineUser } from 'react-icons/ai';
 import { Link } from 'react-router-dom';
+import PATH_URL from '../../constants/pathUrl';
 
-const UserBtn = ({ url }: { url?: string }) => {
+const UserBtn = ({ url, memberId }: { url?: string, memberId: number }) => {
+
   return (
     <StyledContainer>
-      <Link to='/mypage'>
+      <Link to={`${PATH_URL.USER_INFO}${memberId}`}>
         {url ? (
           <img src={url} alt='유저 프로필 이미지' />
         ) : (

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import LoginFieldsContainer from '../components/Login/LoginFieldsContainer';
 import LoginTopWrapper from '../components/Login/LoginTopWrapper';
 import LoginOauthContainer from '../components/Login/LoginOauthContainer';
-import LoginButtonsContainer from '../components/Login/LogInButtonsContainer';
+import LoginButtonsContainer from '../components/Login/LoginButtonsContainer';
 
 const LogIn = () => {
   const navigation = useNavigate();

--- a/client/src/pages/UserInfoPage.tsx
+++ b/client/src/pages/UserInfoPage.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from 'styled-components';
+import MyTitle from '../components/UserInfo/UserTitle';
+
+const UserInfoPage = () => {
+  return (
+    <StyledMyPageWrapper>
+      <StyledMyPageContain>
+        <MyTitle />
+      </StyledMyPageContain>
+    </StyledMyPageWrapper>
+  );
+};
+
+export default UserInfoPage;
+
+const StyledMyPageWrapper = styled.div`
+  background-color: var(--page-bg);
+  width: 100%;
+  min-height: calc(100vh - 224px);
+  flex-grow: 1;
+  overflow-x: hidden;
+`;
+
+const StyledMyPageContain = styled.div`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  padding: 0px;
+  display: flex;
+  justify-content: left;
+  flex-direction: row;
+  gap: 20px;
+`;

--- a/client/src/types/dataTypes.ts
+++ b/client/src/types/dataTypes.ts
@@ -62,6 +62,7 @@ export type PathUrlType = {
   EDIT: string;
   ERROR: string;
   NOTFOUND: string;
+  USER_INFO: string;
 };
 
 export type PostOptionType = {

--- a/client/src/types/propsTypes.ts
+++ b/client/src/types/propsTypes.ts
@@ -40,4 +40,8 @@ export type PostListProps = {
   isSelectTab: string;
   isSelectTag: string;
   isMappingTag: string;
-}
+};
+
+export type StyledUserImgType = {
+  getUserImg : string;
+};


### PR DESCRIPTION
## 추가 변동사항

- 마이페이지와 타유저페이지가 겹치는 기능이 너무 많아서, useParams로 memberId를 전달받아 로그인시에 로컬에 저장된 memberId와 일치하는지 판단해서 구분지었습니다. (페이지를 하나로 합침- 같으면 마이페이지, 다르면 타유저페이지 이런식)

- 외부에서 타유저페이지로 이동할때는, 해당 데이터에 포함된 타유저의 memberId를 경로에 전달해야할 것 같습니다.

- 회원가입시에 username으로 요청하는것 같은데, 마이페이지에서 해당 유저 정보에 대한 api get조회시 userName으로 와서 null 값이 담겨져 옵니다.
(데이터를 한번 확인해봐야 할 것 같습니다., null값이라 유저 닉네임 조회가 안됨)
